### PR TITLE
fix: detach bridge before Server.Reset() on StartServer fail paths

### DIFF
--- a/Source/Claireon/Private/ClaireonModule.cpp
+++ b/Source/Claireon/Private/ClaireonModule.cpp
@@ -2281,6 +2281,7 @@ void FClaireonModule::StartServer()
 			TEXT("Scripts/Utilities/Invoke-MultiWorktreeProxyMigration.ps1) ")
 			TEXT("and relaunch the editor."),
 			static_cast<uint32>(PreferredPort));
+		FClaireonBridge::SetToolRegistry(nullptr);
 		Server.Reset();
 		ProxyClient.Reset();
 		return;
@@ -2293,6 +2294,7 @@ void FClaireonModule::StartServer()
 	{
 		UE_LOG(LogClaireon, Error,
 			TEXT("[MCP] Failed to bind ephemeral listener for proxy mode."));
+		FClaireonBridge::SetToolRegistry(nullptr);
 		Server.Reset();
 		ProxyClient.Reset();
 		return;


### PR DESCRIPTION
## Summary
- Two early-return paths in `FClaireonModule::StartServer` call `Server.Reset()` without first clearing `FClaireonBridge`'s static raw `GServerInstance`.
- `ShutdownModule` (line 2030) already does this and has an explicit comment noting that leaving a dangling pointer is unsafe; the failure-path resets at lines 2284 and 2296 missed the same guard.
- When `OnPythonInitialized` fires later, `BuildAndRunBootstrap` dereferences `GServerInstance`. We hit either:
  - `TConstSetBitIterator<...>::FindFirstSetBit` reading `0xffffffffffffffff` while iterating the freed `Tools` TMap (ClaireonBridge.cpp:550), or
  - The MRSW access detector on the freed `OnToolsChanged` delegate when `AddLambda` is called (ClaireonBridge.cpp:178).

## Repro
1. Launch the editor with `-StartMCPServer` while the SHA-derived port (e.g. 53828) is held by another process.
2. `[MCP] Auto-starting server` -> `failed to start listening on port N!` -> `Port N is held by an unknown process and no Claireon proxy is running on 43017`.
3. `Server.Reset()` at line 2284 runs, leaving `GServerInstance` dangling.
4. `OnPythonInitialized` fires shortly after; `EXCEPTION_ACCESS_VIOLATION reading address 0xffffffffffffffff`.

## Fix
Mirror the safe pattern from `ShutdownModule`: call `FClaireonBridge::SetToolRegistry(nullptr);` immediately before each early-return `Server.Reset()` in `StartServer`.

## Test plan
- [ ] Reproduce the crash by holding the SHA port while launching the editor with `-StartMCPServer`. Editor should now log the port-busy error and continue without crashing during Python init.
- [ ] Normal launch (port free) still binds and bootstraps the bridge.