### PR TITLE
UE 5.8 compatibility

### DIFF
--- a/Source/Claireon/Private/ClaireonBPTranslateSession.cpp
+++ b/Source/Claireon/Private/ClaireonBPTranslateSession.cpp
@@ -129,11 +129,11 @@ FClaireonBPTranslateSession FClaireonBPTranslateSession::LoadFromFile(const FStr
 					NodeStatus.Status = NodeObj->GetStringField(TEXT("status"));
 					NodeStatus.Type = NodeObj->GetStringField(TEXT("type"));
 					NodeStatus.Name = NodeObj->GetStringField(TEXT("name"));
-					BPState.Nodes.Add(NodePair.Key, NodeStatus);
+					BPState.Nodes.Add(FString(*NodePair.Key), NodeStatus);
 				}
 			}
 
-			Session.Blueprints.Add(BPPair.Key, BPState);
+			Session.Blueprints.Add(FString(*BPPair.Key), BPState);
 		}
 	}
 

--- a/Source/Claireon/Private/ClaireonBridge.cpp
+++ b/Source/Claireon/Private/ClaireonBridge.cpp
@@ -608,7 +608,10 @@ void FClaireonBridge::BuildAndRunBootstrap()
 			const TSharedPtr<FJsonObject>* PropertiesObj = nullptr;
 			if (Schema->TryGetObjectField(TEXT("properties"), PropertiesObj))
 			{
-				(*PropertiesObj)->Values.GetKeys(PropertyNames);
+				for (const auto& PropPair : (*PropertiesObj)->Values)
+				{
+					PropertyNames.Add(FString(*PropPair.Key));
+				}
 			}
 
 			// Build this tool's JSON entry

--- a/Source/Claireon/Private/ClaireonToolSearchIndex.cpp
+++ b/Source/Claireon/Private/ClaireonToolSearchIndex.cpp
@@ -277,7 +277,7 @@ namespace Cl628IdxInternal
 		for (const auto& PropPair : (*PropertiesObj)->Values)
 		{
 			// Parameter name
-			Parts.Add(PropPair.Key);
+			Parts.Add(FString(*PropPair.Key));
 
 			const TSharedPtr<FJsonObject>* PropSchema = nullptr;
 			if (!PropPair.Value.IsValid() || !PropPair.Value->TryGetObject(PropSchema) || !PropSchema)

--- a/Source/Claireon/Private/ClaireonWidgetHelpers.cpp
+++ b/Source/Claireon/Private/ClaireonWidgetHelpers.cpp
@@ -29,6 +29,8 @@
 #include "WidgetBlueprintExtension.h"
 #include "Types/MVVMBindingMode.h"
 #include "Kismet2/BlueprintEditorUtils.h"
+#include "Misc/EngineVersionComparison.h"
+#include "UObject/Package.h"
 
 // ============================================================================
 // SerializeWidgetTree
@@ -333,7 +335,80 @@ UWidget* ClaireonWidgetHelpers::CreateWidget(UWidgetTree* Tree, TSubclassOf<UWid
 		return nullptr;
 	}
 
-	return Tree->ConstructWidget<UWidget>(WidgetClass, WidgetName);
+	UWidget* Widget = Tree->ConstructWidget<UWidget>(WidgetClass, WidgetName);
+	if (Widget)
+	{
+		NotifyVariableAdded(Cast<UWidgetBlueprint>(Tree->GetOuter()), Widget->GetFName());
+	}
+	return Widget;
+}
+
+// ============================================================================
+// Widget variable GUID bookkeeping (UE 5.8+)
+// ============================================================================
+
+void ClaireonWidgetHelpers::NotifyVariableAdded(UWidgetBlueprint* WidgetBP, FName VariableName)
+{
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+	if (WidgetBP && !VariableName.IsNone() && !WidgetBP->WidgetVariableNameToGuidMap.Contains(VariableName))
+	{
+		WidgetBP->OnVariableAdded(VariableName);
+	}
+#endif
+}
+
+void ClaireonWidgetHelpers::NotifyVariableRemoved(UWidgetBlueprint* WidgetBP, FName VariableName)
+{
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+	if (WidgetBP && !VariableName.IsNone())
+	{
+		WidgetBP->OnVariableRemoved(VariableName);
+	}
+#endif
+}
+
+void ClaireonWidgetHelpers::NotifyVariableRenamed(UWidgetBlueprint* WidgetBP, FName OldName, FName NewName)
+{
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+	if (!WidgetBP || NewName.IsNone() || OldName == NewName)
+	{
+		return;
+	}
+	// OnVariableRenamed ensures on a missing old entry and an existing new entry;
+	// pre-check so assets created before this bookkeeping existed stay quiet.
+	if (WidgetBP->WidgetVariableNameToGuidMap.Contains(OldName) &&
+		!WidgetBP->WidgetVariableNameToGuidMap.Contains(NewName))
+	{
+		WidgetBP->OnVariableRenamed(OldName, NewName);
+	}
+	else
+	{
+		NotifyVariableAdded(WidgetBP, NewName);
+	}
+#endif
+}
+
+void ClaireonWidgetHelpers::TrashRemovedWidget(UWidgetBlueprint* WidgetBP, UWidget* Widget)
+{
+	if (!Widget)
+	{
+		return;
+	}
+	// Engine designer pattern (FWidgetBlueprintEditorUtils::DeleteWidgets): removed
+	// widgets stay outered to the widget tree, so until they are reparented to the
+	// transient package they still count as source widgets (5.8's GUID validation
+	// resurrects their map entries) and their names collide with future widgets.
+	TArray<UWidget*> Subtree;
+	Subtree.Add(Widget);
+	UWidgetTree::GetChildWidgets(Widget, Subtree);
+	for (UWidget* Removed : Subtree)
+	{
+		const FName RemovedName = Removed->GetFName();
+		Removed->SetFlags(RF_Transactional);
+		Removed->Modify();
+		Removed->Rename(nullptr, GetTransientPackage());
+		NotifyVariableRemoved(WidgetBP, RemovedName);
+	}
 }
 
 // ============================================================================
@@ -367,7 +442,7 @@ UPanelSlot* ClaireonWidgetHelpers::AddChildToPanel(UPanelWidget* Parent, UWidget
 			}
 			FString PropStrVal = Pair.Value.IsValid() ? Pair.Value->AsString() : TEXT("");
 			FString Error;
-			WriteSlotProperty(Slot, Pair.Key, PropStrVal, Error);
+			WriteSlotProperty(Slot, FString(*Pair.Key), PropStrVal, Error);
 		}
 	}
 

--- a/Source/Claireon/Private/ClaireonXmlFormatter.cpp
+++ b/Source/Claireon/Private/ClaireonXmlFormatter.cpp
@@ -308,7 +308,7 @@ FString FClaireonXmlFormatter::GenerateTypeSignature(const FString& ToolName, co
 	TArray<FString> ParamStrings;
 	for (const auto& Pair : (*PropertiesPtr)->Values)
 	{
-		const FString& ParamName = Pair.Key;
+		const FString ParamName(*Pair.Key);
 		const TSharedPtr<FJsonObject>* PropObj = nullptr;
 
 		FString TypeStr = TEXT("any");

--- a/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Batch.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Batch.cpp
@@ -327,7 +327,7 @@ FToolResult ClaireonAnimGraphTool_ApplyDelta::Execute(const TSharedPtr<FJsonObje
 					if (Pair.Value.IsValid() && Pair.Value->TryGetString(Value))
 					{
 						FString PropError;
-						if (!ClaireonPropertyUtils::WritePropertyByPath(NewNode, Pair.Key, Value, PropError))
+						if (!ClaireonPropertyUtils::WritePropertyByPath(NewNode, FString(*Pair.Key), Value, PropError))
 						{
 							Warnings.Add(FString::Printf(TEXT("Node '%s': property '%s': %s"), *LocalId, *Pair.Key, *PropError));
 						}

--- a/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Node.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Node.cpp
@@ -191,7 +191,7 @@ FToolResult ClaireonAnimGraphTool_AddNode::Execute(const TSharedPtr<FJsonObject>
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(Value))
 			{
 				FString PropError;
-				if (!ClaireonPropertyUtils::WritePropertyByPath(NewNode, Pair.Key, Value, PropError))
+				if (!ClaireonPropertyUtils::WritePropertyByPath(NewNode, FString(*Pair.Key), Value, PropError))
 				{
 					Warnings.Add(FString::Printf(TEXT("Failed to set property '%s': %s"), *Pair.Key, *PropError));
 				}

--- a/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Variable.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Variable.cpp
@@ -292,7 +292,7 @@ FToolResult ClaireonAnimGraphTool_SetVariableProperties::Execute(const TSharedPt
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(Value))
 			{
 				FBlueprintEditorUtils::SetBlueprintVariableMetaData(AnimBP, VarFName, LocalScope, FName(*Pair.Key), Value);
-				ChangedProps.Add(Pair.Key);
+				ChangedProps.Add(FString(*Pair.Key));
 			}
 		}
 	}

--- a/Source/Claireon/Private/Tools/ClaireonAnimTools_Notify.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAnimTools_Notify.cpp
@@ -121,7 +121,7 @@ IClaireonTool::FToolResult ClaireonAnimTool_AddNotify::Execute(const TSharedPtr<
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(PropValue))
 			{
 				FString PropError;
-				ClaireonAnimHelpers::SetNotifyProperty(Anim, NewIndex, Pair.Key, PropValue, PropError);
+				ClaireonAnimHelpers::SetNotifyProperty(Anim, NewIndex, FString(*Pair.Key), PropValue, PropError);
 				if (!PropError.IsEmpty())
 				{
 					UE_LOG(LogClaireon, Warning, TEXT("AddNotify: Failed to set property '%s': %s"), *Pair.Key, *PropError);

--- a/Source/Claireon/Private/Tools/ClaireonAudioApplyHelpers.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAudioApplyHelpers.cpp
@@ -117,11 +117,11 @@ namespace ClaireonAudioApplyHelpers
 			if (AActor* AsActor = Cast<AActor>(Target))
 			{
 				ClaireonPropertyResolver::FResolvedProperty Resolved;
-				bOk = ClaireonPropertyResolver::WritePropertyOnActor(AsActor, Pair.Key, ValueStr, Resolved, Err);
+				bOk = ClaireonPropertyResolver::WritePropertyOnActor(AsActor, FString(*Pair.Key), ValueStr, Resolved, Err);
 			}
 			else
 			{
-				bOk = ClaireonPropertyUtils::WritePropertyByPath(Target, Pair.Key, ValueStr, Err);
+				bOk = ClaireonPropertyUtils::WritePropertyByPath(Target, FString(*Pair.Key), ValueStr, Err);
 			}
 			if (!bOk)
 			{

--- a/Source/Claireon/Private/Tools/ClaireonBlueprintGraphTool_Compile.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonBlueprintGraphTool_Compile.cpp
@@ -145,7 +145,14 @@ FToolResult ClaireonBlueprintGraphTool_Compile::Execute(const TSharedPtr<FJsonOb
 	FCompilerResultsLog CompilerLog;
 	CompilerLog.SetSourcePath(Blueprint->GetPathName());
 	CompilerLog.BeginEvent(TEXT("Compile"));
-	FKismetEditorUtilities::CompileBlueprint(Blueprint, EBlueprintCompileOptions::None, &CompilerLog);
+	// SkipSave: compile is documented as in-memory only (bp_save persists), and
+	// matches UBlueprintEditorLibrary::CompileBlueprint. SkipGarbageCollection:
+	// the synchronous CollectGarbage at the end of a compile livelocks on UE 5.8
+	// when invoked from inside the MCP request handler (the editor saturates all
+	// cores and the call never returns); the editor GCs on its own cadence soon
+	// after instead.
+	FKismetEditorUtilities::CompileBlueprint(Blueprint,
+		EBlueprintCompileOptions::SkipSave | EBlueprintCompileOptions::SkipGarbageCollection, &CompilerLog);
 	CompilerLog.EndEvent();
 
 	// Check compilation status

--- a/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_Compile.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_Compile.cpp
@@ -19,6 +19,9 @@
 #else
 #include "Build/CameraBuildLog.h"
 #endif
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+#include "Build/CameraBuildContext.h"
+#endif
 
 FString FClaireonCameraAssetTool_Compile::GetOperation() const { return TEXT("compile"); }
 
@@ -59,7 +62,12 @@ IClaireonTool::FToolResult FClaireonCameraAssetTool_Compile::Execute(const TShar
 	}
 
 	UE::Cameras::FCameraBuildLog Log;
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	Asset->BuildCamera(Log);
+#else
+	UE::Cameras::FCameraBuildContext BuildContext(Log);
+	Asset->BuildCamera(BuildContext);
+#endif
 
 	bool bHasErrors = false;
 	for (const UE::Cameras::FCameraBuildLogMessage& M : Log.GetMessages())

--- a/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_Save.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_Save.cpp
@@ -21,6 +21,9 @@
 #else
 #include "Build/CameraBuildLog.h"
 #endif
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+#include "Build/CameraBuildContext.h"
+#endif
 
 FString FClaireonCameraAssetTool_Save::GetOperation() const { return TEXT("save"); }
 
@@ -65,7 +68,12 @@ IClaireonTool::FToolResult FClaireonCameraAssetTool_Save::Execute(const TSharedP
 	// triggers the discard-overload PreSave path. The dual call is intentional —
 	// PreSave's rebuild against the same in-memory state is largely idempotent.
 	UE::Cameras::FCameraBuildLog Log;
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	Asset->BuildCamera(Log);
+#else
+	UE::Cameras::FCameraBuildContext BuildContext(Log);
+	Asset->BuildCamera(BuildContext);
+#endif
 
 	int32 ErrorCount = 0;
 	for (const UE::Cameras::FCameraBuildLogMessage& M : Log.GetMessages())

--- a/Source/Claireon/Private/Tools/ClaireonChooserTool_RemoveRow.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonChooserTool_RemoveRow.cpp
@@ -9,6 +9,7 @@
 #include "ScopedTransaction.h"
 #include "Dom/JsonObject.h"
 #include "StructUtils/InstancedStruct.h"
+#include "Misc/EngineVersionComparison.h"
 
 FString ClaireonTool_ChooserRemoveRow::GetCategory() const { return TEXT("chooser"); }
 FString ClaireonTool_ChooserRemoveRow::GetOperation() const { return TEXT("remove_row"); }
@@ -68,8 +69,14 @@ IClaireonTool::FToolResult ClaireonTool_ChooserRemoveRow::Execute(const TSharedP
 	}
 
 	// Remove from each column's RowValues
+	// 5.8 changed FChooserColumnBase::DeleteRows to take TArrayView<int>.
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	TArray<uint32> RowIndices;
 	RowIndices.Add(static_cast<uint32>(RowIndex));
+#else
+	TArray<int32> RowIndices;
+	RowIndices.Add(RowIndex);
+#endif
 	for (FInstancedStruct& ColStruct : Chooser->ColumnsStructs)
 	{
 		if (ColStruct.IsValid())

--- a/Source/Claireon/Private/Tools/ClaireonDataTableHelpers.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonDataTableHelpers.cpp
@@ -235,7 +235,7 @@ bool SetPropertyValues(UDataTable* DataTable, FName RowName, const TSharedPtr<FJ
 
 	for (const auto& Pair : Values->Values)
 	{
-		const FString& Key = Pair.Key;
+		const FString Key(*Pair.Key);
 		const TSharedPtr<FJsonValue>& JsonValue = Pair.Value;
 
 		FProperty* Property = RowStruct->FindPropertyByName(FName(*Key));

--- a/Source/Claireon/Private/Tools/ClaireonMaterialTool_AddExpression.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonMaterialTool_AddExpression.cpp
@@ -89,7 +89,7 @@ FToolResult ClaireonMaterialTool_AddExpression::Execute(const TSharedPtr<FJsonOb
 			if (!Pair.Value.IsValid()) continue;
 			const FString TextValue = Pair.Value->AsString();
 			FString PropErr;
-			ClaireonMaterialHelpers::SetExpressionProperty(Material, Expr, Pair.Key, TextValue, PropErr);
+			ClaireonMaterialHelpers::SetExpressionProperty(Material, Expr, FString(*Pair.Key), TextValue, PropErr);
 		}
 	}
 

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_BehaviorTree.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_BehaviorTree.cpp
@@ -412,7 +412,7 @@ bool FClaireonSpecApplicator_BehaviorTree::ApplyPass2_WireRelationships(const FS
 							if (Prop.Value->TryGetString(PropValue))
 							{
 								FString PropError;
-								if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, Prop.Key, PropValue, PropError))
+								if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, FString(*Prop.Key), PropValue, PropError))
 								{
 									AddWarning(FString::Printf(TEXT("Decorator '%s' property '%s': %s"), *DecId, *Prop.Key, *PropError));
 								}
@@ -480,7 +480,7 @@ bool FClaireonSpecApplicator_BehaviorTree::ApplyPass2_WireRelationships(const FS
 							if (Prop.Value->TryGetString(PropValue))
 							{
 								FString PropError;
-								if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, Prop.Key, PropValue, PropError))
+								if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, FString(*Prop.Key), PropValue, PropError))
 								{
 									AddWarning(FString::Printf(TEXT("Service '%s' property '%s': %s"), *SvcId, *Prop.Key, *PropError));
 								}
@@ -504,7 +504,7 @@ bool FClaireonSpecApplicator_BehaviorTree::ApplyPass2_WireRelationships(const FS
 					if (Prop.Value->TryGetString(PropValue))
 					{
 						FString PropError;
-						if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, Prop.Key, PropValue, PropError))
+						if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, FString(*Prop.Key), PropValue, PropError))
 						{
 							AddWarning(FString::Printf(TEXT("Node '%s' property '%s': %s"), *SpecId, *Prop.Key, *PropError));
 						}

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_EQS.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_EQS.cpp
@@ -291,7 +291,7 @@ bool FClaireonSpecApplicator_EQS::ApplyPass2_WireRelationships(const FString& Se
 					if (Prop.Value->TryGetString(PropValue))
 					{
 						FString PropError;
-						if (!SpecApplicatorEQS_SetEQSProperty(Option->Generator, Prop.Key, PropValue, PropError))
+						if (!SpecApplicatorEQS_SetEQSProperty(Option->Generator, FString(*Prop.Key), PropValue, PropError))
 						{
 							AddWarning(FString::Printf(TEXT("Option '%s' generator property '%s': %s"), *SpecId, *Prop.Key, *PropError));
 						}
@@ -338,7 +338,7 @@ bool FClaireonSpecApplicator_EQS::ApplyPass2_WireRelationships(const FString& Se
 						if (Prop.Value->TryGetString(PropValue))
 						{
 							FString PropError;
-							if (!SpecApplicatorEQS_SetEQSProperty(NewTest, Prop.Key, PropValue, PropError))
+							if (!SpecApplicatorEQS_SetEQSProperty(NewTest, FString(*Prop.Key), PropValue, PropError))
 							{
 								AddWarning(FString::Printf(TEXT("Test '%s' property '%s': %s"), *TestId, *Prop.Key, *PropError));
 							}

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_Material.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_Material.cpp
@@ -364,7 +364,7 @@ bool FClaireonSpecApplicator_Material::ApplyPass1_CreateEntities(const FString& 
 					TextValue = Pair.Value->AsString(); // best-effort coercion
 				}
 				FString PropErr;
-				if (!ClaireonMaterialHelpers::SetExpressionProperty(Mat, Expr, Pair.Key, TextValue, PropErr))
+				if (!ClaireonMaterialHelpers::SetExpressionProperty(Mat, Expr, FString(*Pair.Key), TextValue, PropErr))
 				{
 					AddWarning(FString::Printf(TEXT("expression '%s': failed to set property '%s' = '%s' (%s)"),
 						*SpecId, *Pair.Key, *TextValue, *PropErr));

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_PCGGraph.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_PCGGraph.cpp
@@ -159,7 +159,7 @@ bool FClaireonSpecApplicator_PCGGraph::ApplyPass1_CreateEntities(const FString& 
 				if (Prop.Value->TryGetString(PropValue))
 				{
 					FString PropError;
-					if (!ClaireonPCGGraphHelpers::SetNodeProperty(NewNode, Prop.Key, PropValue, PropError))
+					if (!ClaireonPCGGraphHelpers::SetNodeProperty(NewNode, FString(*Prop.Key), PropValue, PropError))
 					{
 						AddWarning(FString::Printf(TEXT("Node '%s' property '%s': %s"), *SpecId, *Prop.Key, *PropError));
 					}

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_StateTree.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_StateTree.cpp
@@ -472,7 +472,7 @@ bool FClaireonSpecApplicator_StateTree::ApplyPass2_WireRelationships(const FStri
 						if (Prop.Value->TryGetString(PropValue))
 						{
 							FString PropError;
-							ClaireonStateTreeHelpers::SetNodeProperty(NewNode, Prop.Key, PropValue, false, PropError);
+							ClaireonStateTreeHelpers::SetNodeProperty(NewNode, FString(*Prop.Key), PropValue, false, PropError);
 						}
 					}
 				}
@@ -611,7 +611,7 @@ bool FClaireonSpecApplicator_StateTree::ApplyPass2_WireRelationships(const FStri
 						if (Prop.Value->TryGetString(PropValue))
 						{
 							FString PropError;
-							ClaireonStateTreeHelpers::SetNodeProperty(Node, Prop.Key, PropValue, false, PropError);
+							ClaireonStateTreeHelpers::SetNodeProperty(Node, FString(*Prop.Key), PropValue, false, PropError);
 						}
 					}
 					break;

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_WidgetBP.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_WidgetBP.cpp
@@ -454,7 +454,7 @@ bool FClaireonSpecApplicator_WidgetBP::ApplyPass2_WireRelationships(const FStrin
 					if (Prop.Value->TryGetString(PropValue))
 					{
 						FString PropError;
-						ClaireonWidgetHelpers::WriteSlotProperty(Slot, Prop.Key, PropValue, PropError);
+						ClaireonWidgetHelpers::WriteSlotProperty(Slot, FString(*Prop.Key), PropValue, PropError);
 					}
 				}
 			}
@@ -482,7 +482,7 @@ bool FClaireonSpecApplicator_WidgetBP::ApplyPass2_WireRelationships(const FStrin
 					if (Prop.Value->TryGetString(PropValue))
 					{
 						FString PropError;
-						if (!ClaireonWidgetHelpers::WriteWidgetProperty(Widget, Prop.Key, PropValue, PropError))
+						if (!ClaireonWidgetHelpers::WriteWidgetProperty(Widget, FString(*Prop.Key), PropValue, PropError))
 						{
 							AddWarning(FString::Printf(TEXT("Widget '%s' property '%s': %s"), *SpecId, *Prop.Key, *PropError));
 						}

--- a/Source/Claireon/Private/Tools/ClaireonStateTreeEditInternal.h
+++ b/Source/Claireon/Private/Tools/ClaireonStateTreeEditInternal.h
@@ -13,6 +13,21 @@
 #include "StateTreeEditorData.h"
 #include "StateTreeEditorNode.h"
 #include "StateTreeTypes.h"
+#include "Misc/EngineVersionComparison.h"
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
+#include "StateTreePropertyBindings.h"
+#else
+#include "PropertyBindingPath.h"
+#endif
+
+// 5.8 removed FStateTreePropertyPath (and the FStateTreeEditorPropertyBindings
+// AddPropertyBinding/RemovePropertyBindings/AddFunctionPropertyBinding entry
+// points) in favor of FPropertyBindingPath and the FPropertyBindingBindingCollection API.
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
+using FClaireonPropertyPath = FStateTreePropertyPath;
+#else
+using FClaireonPropertyPath = FPropertyBindingPath;
+#endif
 
 namespace ClaireonStateTreeEditInternal
 {
@@ -226,9 +241,9 @@ namespace ClaireonStateTreeEditInternal
 			{
 				FString Error;
 				// Try on node struct first, then instance data
-				if (!ClaireonStateTreeHelpers::SetNodeProperty(Node, Pair.Key, Value, false, Error))
+				if (!ClaireonStateTreeHelpers::SetNodeProperty(Node, FString(*Pair.Key), Value, false, Error))
 				{
-					ClaireonStateTreeHelpers::SetNodeProperty(Node, Pair.Key, Value, true, Error);
+					ClaireonStateTreeHelpers::SetNodeProperty(Node, FString(*Pair.Key), Value, true, Error);
 				}
 			}
 		}

--- a/Source/Claireon/Private/Tools/ClaireonStateTreeHelpers.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonStateTreeHelpers.cpp
@@ -15,7 +15,7 @@
 #include "StateTreeNodeBase.h"
 #include "StateTreePropertyBindings.h"
 #include "StateTreeEditorPropertyBindings.h"
-#include "InstancedStruct.h"
+#include "StructUtils/InstancedStruct.h"
 #include "GameplayTagContainer.h"
 
 // ============================================================================

--- a/Source/Claireon/Private/Tools/ClaireonStateTreeTool_AddBinding.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonStateTreeTool_AddBinding.cpp
@@ -58,17 +58,21 @@ FToolResult ClaireonStateTreeTool_AddBinding::Execute(const TSharedPtr<FJsonObje
 		return MakeErrorResult(TEXT("Missing parameter: target_property"));
 
 #if WITH_EDITORONLY_DATA
-	FStateTreePropertyPath SourcePath(SourceNodeId);
+	FClaireonPropertyPath SourcePath(SourceNodeId);
 	SourcePath.FromString(SourceProperty);
 
-	FStateTreePropertyPath TargetPath(TargetNodeId);
+	FClaireonPropertyPath TargetPath(TargetNodeId);
 	TargetPath.FromString(TargetProperty);
 
 	FScopedTransaction Transaction(FText::FromString(TEXT("[Claireon] Add Property Binding")));
 	Data->StateTree->Modify();
 
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	FStateTreePropertyPathBinding Binding(SourcePath, TargetPath);
 	EditorData->EditorBindings.AddPropertyBinding(Binding);
+#else
+	EditorData->EditorBindings.AddBinding(SourcePath, TargetPath);
+#endif
 
 	Data->LastOperationStatus = FString::Printf(TEXT("add_binding -> Bound %s -> %s"), *SourceProperty, *TargetProperty);
 #else

--- a/Source/Claireon/Private/Tools/ClaireonStateTreeTool_AddPropertyFunction.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonStateTreeTool_AddPropertyFunction.cpp
@@ -86,13 +86,13 @@ FToolResult ClaireonStateTreeTool_AddPropertyFunction::Execute(const TSharedPtr<
 		return MakeErrorResult(FString::Printf(TEXT("'%s' is not a property function (must derive from FStateTreePropertyFunctionBase)"), *StructName));
 	}
 
-	FStateTreePropertyPath TargetPath(TargetNodeId);
+	FClaireonPropertyPath TargetPath(TargetNodeId);
 	TargetPath.FromString(TargetProperty);
 
 	TArray<FClaireonPropertyPathSegment> SourceSegments;
 	if (!SourceProperty.IsEmpty())
 	{
-		FStateTreePropertyPath TempPath;
+		FClaireonPropertyPath TempPath;
 		TempPath.FromString(SourceProperty);
 		SourceSegments = TempPath.GetSegments();
 	}
@@ -121,7 +121,11 @@ FToolResult ClaireonStateTreeTool_AddPropertyFunction::Execute(const TSharedPtr<
 	FScopedTransaction Transaction(FText::FromString(TEXT("[Claireon] Add Property Function Binding")));
 	Data->StateTree->Modify();
 
-	FStateTreePropertyPath ResultSourcePath = EditorData->EditorBindings.AddFunctionPropertyBinding(NodeStruct, SourceSegments, TargetPath);
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
+	FClaireonPropertyPath ResultSourcePath = EditorData->EditorBindings.AddFunctionPropertyBinding(NodeStruct, SourceSegments, TargetPath);
+#else
+	FClaireonPropertyPath ResultSourcePath = EditorData->EditorBindings.AddFunctionBinding(NodeStruct, SourceSegments, TargetPath);
+#endif
 
 	// Locate the just-added binding by target path, capture its embedded function-node
 	// GUID, and apply any optional initial properties in the same pass.
@@ -144,7 +148,7 @@ FToolResult ClaireonStateTreeTool_AddPropertyFunction::Execute(const TSharedPtr<
 						FString PropValue;
 						if (Pair.Value->TryGetString(PropValue))
 						{
-							ClaireonStateTreeHelpers::SetNodeProperty(EditorNode, Pair.Key, PropValue, true, Error);
+							ClaireonStateTreeHelpers::SetNodeProperty(EditorNode, FString(*Pair.Key), PropValue, true, Error);
 							if (!Error.IsEmpty())
 							{
 								UE_LOG(LogClaireon, Warning, TEXT("AddPropertyFunction: Failed to set property '%s': %s"), *Pair.Key, *Error);

--- a/Source/Claireon/Private/Tools/ClaireonStateTreeTool_RemoveBinding.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonStateTreeTool_RemoveBinding.cpp
@@ -52,12 +52,16 @@ FToolResult ClaireonStateTreeTool_RemoveBinding::Execute(const TSharedPtr<FJsonO
 		return MakeErrorResult(TEXT("Missing parameter: target_property"));
 
 #if WITH_EDITORONLY_DATA
-	FStateTreePropertyPath TargetPath(TargetNodeId);
+	FClaireonPropertyPath TargetPath(TargetNodeId);
 	TargetPath.FromString(TargetProperty);
 
 	FScopedTransaction Transaction(FText::FromString(TEXT("[Claireon] Remove Property Binding")));
 	Data->StateTree->Modify();
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	EditorData->EditorBindings.RemovePropertyBindings(TargetPath);
+#else
+	EditorData->EditorBindings.RemoveBindings(TargetPath);
+#endif
 
 	Data->LastOperationStatus = FString::Printf(TEXT("remove_binding -> Removed binding to %s"), *TargetProperty);
 #else

--- a/Source/Claireon/Private/Tools/ClaireonTool_BlueprintDiff.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_BlueprintDiff.cpp
@@ -232,7 +232,7 @@ void BuildSpecNodeEntry(const TSharedPtr<FJsonObject>& NodeObj, FSpecNodeEntry& 
 			FString PinValue;
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(PinValue))
 			{
-				Out.PinDefaults.Add(Pair.Key, PinValue);
+				Out.PinDefaults.Add(FString(*Pair.Key), PinValue);
 			}
 		}
 	}

--- a/Source/Claireon/Private/Tools/ClaireonTool_DataTableSetRowValues.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_DataTableSetRowValues.cpp
@@ -112,7 +112,7 @@ IClaireonTool::FToolResult ClaireonTool_DataTableSetRowValues::Execute(const TSh
 
 	for (const auto& Pair : Values->Values)
 	{
-		const FString& Key = Pair.Key;
+		const FString Key(*Pair.Key);
 
 		const FProperty* Prop = RowStruct ? RowStruct->FindPropertyByName(FName(*Key)) : nullptr;
 		if (!Prop)

--- a/Source/Claireon/Private/Tools/ClaireonTool_PlaceActor.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_PlaceActor.cpp
@@ -387,7 +387,7 @@ FToolResult ClaireonTool_PlaceActor::Execute(const TSharedPtr<FJsonObject>& Argu
 
 				ClaireonPropertyResolver::FResolvedProperty Resolved;
 				FString WriteError;
-				bool bOk = ClaireonPropertyResolver::WritePropertyOnActor(SpawnedActor, Pair.Key, ValueStr, Resolved, WriteError);
+				bool bOk = ClaireonPropertyResolver::WritePropertyOnActor(SpawnedActor, FString(*Pair.Key), ValueStr, Resolved, WriteError);
 				if (!bOk)
 				{
 					UE_LOG(LogClaireon, Warning, TEXT("[place_actor] %s"), *WriteError);

--- a/Source/Claireon/Private/Tools/ClaireonTool_ReplaceStructUsage.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_ReplaceStructUsage.cpp
@@ -308,7 +308,7 @@ FToolResult ClaireonTool_ReplaceStructUsage::Execute(const TSharedPtr<FJsonObjec
 			FString V;
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(V))
 			{
-				FieldMap.Add(Pair.Key, V);
+				FieldMap.Add(FString(*Pair.Key), V);
 			}
 		}
 	}

--- a/Source/Claireon/Private/Tools/ClaireonWidgetAnimationHandlers.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetAnimationHandlers.cpp
@@ -17,6 +17,7 @@
 #include "WidgetBlueprint.h"
 
 #include "Tools/ClaireonSequenceHelpers.h"
+#include "ClaireonWidgetHelpers.h"
 
 // ============================================================================
 // Widget-animation Apply handlers -- free functions used by the per-op
@@ -92,6 +93,7 @@ bool ApplyCreateAnimation(UWidgetBlueprint* WBP, const FString& AnimationName, f
 
 	WBP->Modify();
 	WBP->Animations.Add(NewAnim);
+	ClaireonWidgetHelpers::NotifyVariableAdded(WBP, NewAnim->GetFName());
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
 
 	OutAnim = NewAnim;
@@ -113,11 +115,13 @@ bool ApplyDeleteAnimation(UWidgetBlueprint* WBP, const FString& AnimationName, F
 		return false;
 	}
 	WBP->Modify();
+	const FName RemovedAnimName = Anim->GetFName();
 	// Engine pattern from AnimationTabSummoner::OnDeleteAnimation: reparent to
 	// transient package so the WBP no longer owns the asset. Avoids future name
 	// collisions; GC sweep reclaims it.
 	Anim->Rename(nullptr, GetTransientPackage(), REN_DontCreateRedirectors);
 	WBP->Animations.Remove(Anim);
+	ClaireonWidgetHelpers::NotifyVariableRemoved(WBP, RemovedAnimName);
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
 	return true;
 }
@@ -151,6 +155,12 @@ bool ApplyRenameAnimation(UWidgetBlueprint* WBP, const FString& OldName, const F
 
 	WBP->Modify();
 	Anim->Modify();
+
+	// Update the GUID bookkeeping before the object renames: Rename() broadcasts
+	// and can trigger an immediate recompile, whose validation expects the map to
+	// already know the new name.
+	ClaireonWidgetHelpers::NotifyVariableRenamed(WBP, OldFName, NewFName);
+
 	if (UMovieScene* MS = Anim->GetMovieScene())
 	{
 		MS->Modify();

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_AddWidget.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_AddWidget.cpp
@@ -173,13 +173,13 @@ FToolResult ClaireonWidgetBPTool_AddWidget::Execute(const TSharedPtr<FJsonObject
 					// passing "" (what AsString() returns for object/array values).
 					FString PropStrVal;
 					FString PropConvErr;
-					if (!AddWidget_SlotPropJsonValueToString(Pair.Key, Pair.Value, PropStrVal, PropConvErr))
+					if (!AddWidget_SlotPropJsonValueToString(FString(*Pair.Key), Pair.Value, PropStrVal, PropConvErr))
 					{
 						UE_LOG(LogClaireon, Warning, TEXT("[EditWidgetBP] add_widget: %s"), *PropConvErr);
 						continue;
 					}
 					FString SlotError;
-					ClaireonWidgetHelpers::WriteSlotProperty(Slot, Pair.Key, PropStrVal, SlotError);
+					ClaireonWidgetHelpers::WriteSlotProperty(Slot, FString(*Pair.Key), PropStrVal, SlotError);
 				}
 			}
 		}

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_Create.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_Create.cpp
@@ -152,7 +152,7 @@ FToolResult ClaireonWidgetBPTool_Create::Execute(const TSharedPtr<FJsonObject>& 
 		}
 		else if (NewWBP->WidgetTree)
 		{
-			UWidget* Root = NewWBP->WidgetTree->ConstructWidget<UWidget>(RootClass, FName(*RootClass->GetName()));
+			UWidget* Root = ClaireonWidgetHelpers::CreateWidget(NewWBP->WidgetTree, RootClass, FName(*RootClass->GetName()));
 			if (Root)
 			{
 				NewWBP->WidgetTree->RootWidget = Root;

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_RemoveWidget.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_RemoveWidget.cpp
@@ -62,6 +62,8 @@ FToolResult ClaireonWidgetBPTool_RemoveWidget::Execute(const TSharedPtr<FJsonObj
 	Tree->SetFlags(RF_Transactional);
 	Tree->Modify();
 
+	const FName RemovedWidgetName = Widget->GetFName();
+
 	if (Tree->RootWidget == Widget)
 	{
 		Tree->RootWidget = nullptr;
@@ -71,11 +73,13 @@ FToolResult ClaireonWidgetBPTool_RemoveWidget::Execute(const TSharedPtr<FJsonObj
 		Tree->RemoveWidget(Widget);
 	}
 
+	ClaireonWidgetHelpers::TrashRemovedWidget(WBP, Widget);
+
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
 	Data->bModified = true;
 
 	// Clear focus if the focused widget was removed
-	if (Data->FocusedWidget == Widget->GetFName())
+	if (Data->FocusedWidget == RemovedWidgetName)
 	{
 		Data->FocusedWidget = Tree->RootWidget ? Tree->RootWidget->GetFName() : NAME_None;
 	}

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_RenameWidget.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_RenameWidget.cpp
@@ -78,6 +78,11 @@ FToolResult ClaireonWidgetBPTool_RenameWidget::Execute(const TSharedPtr<FJsonObj
 
 	FName OldFName = Widget->GetFName();
 
+	// Update the GUID bookkeeping before the object rename: Rename() broadcasts
+	// and can trigger an immediate recompile, whose validation expects the map to
+	// already know the new name.
+	ClaireonWidgetHelpers::NotifyVariableRenamed(WBP, OldFName, FName(*NewName));
+
 	// Rename the UObject
 	Widget->Rename(*NewName, Widget->GetOuter());
 

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_ReplaceWidget.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_ReplaceWidget.cpp
@@ -137,11 +137,14 @@ FToolResult ClaireonWidgetBPTool_ReplaceWidget::Execute(const TSharedPtr<FJsonOb
 		UE_LOG(LogClaireon, Warning, TEXT("[EditWidgetBP] Replacement widget '%s' is not a panel -- %d children were lost"), *NewWidgetClassStr, OldChildren.Num());
 	}
 
+	const FName OldWidgetFName = OldWidget->GetFName();
+	ClaireonWidgetHelpers::TrashRemovedWidget(WBP, OldWidget);
+
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
 	Data->bModified = true;
 
 	// Update focus if needed
-	if (Data->FocusedWidget == OldWidget->GetFName())
+	if (Data->FocusedWidget == OldWidgetFName)
 	{
 		Data->FocusedWidget = NewWidget->GetFName();
 	}

--- a/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_BehaviorTree.cpp
+++ b/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_BehaviorTree.cpp
@@ -390,7 +390,7 @@ bool FClaireonDeltaApplicator_BehaviorTree::ApplyPhase3_Create(const FString& Se
 					if (Prop.Value->TryGetString(PropValue))
 					{
 						FString PropError;
-						if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(InstNode, Prop.Key, PropValue, PropError))
+						if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(InstNode, FString(*Prop.Key), PropValue, PropError))
 						{
 							AddWarning(FString::Printf(TEXT("behaviortree_apply_delta: nodes[%d].properties.%s: %s"),
 								i, *Prop.Key, *PropError));

--- a/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_Material.cpp
+++ b/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_Material.cpp
@@ -260,7 +260,7 @@ bool FClaireonDeltaApplicator_Material::ApplyPhase3_Create(const FString& Sessio
 				if (!Pair.Value.IsValid()) { continue; }
 				const FString TextValue = Pair.Value->AsString();
 				FString PropErr;
-				if (!ClaireonMaterialHelpers::SetExpressionProperty(Mat, Expr, Pair.Key, TextValue, PropErr))
+				if (!ClaireonMaterialHelpers::SetExpressionProperty(Mat, Expr, FString(*Pair.Key), TextValue, PropErr))
 				{
 					AddWarning(FString::Printf(TEXT("material_apply_delta: nodes[%d] property '%s': %s"),
 						i, *Pair.Key, *PropErr));

--- a/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_PCGGraph.cpp
+++ b/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_PCGGraph.cpp
@@ -290,7 +290,7 @@ bool FClaireonDeltaApplicator_PCGGraph::ApplyPhase3_Create(const FString& Sessio
 				if (Prop.Value->TryGetString(PropValue))
 				{
 					FString PropError;
-					if (!ClaireonPCGGraphHelpers::SetNodeProperty(NewNode, Prop.Key, PropValue, PropError))
+					if (!ClaireonPCGGraphHelpers::SetNodeProperty(NewNode, FString(*Prop.Key), PropValue, PropError))
 					{
 						AddWarning(FString::Printf(TEXT("pcg_apply_delta: nodes[%d].properties.%s: %s"), i, *Prop.Key, *PropError));
 					}

--- a/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_WidgetBP.cpp
+++ b/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_WidgetBP.cpp
@@ -169,6 +169,7 @@ bool FClaireonDeltaApplicator_WidgetBP::ApplyPhase2_Remove(const FString& Sessio
 		{
 			Tree->RemoveWidget(Widget);
 		}
+		ClaireonWidgetHelpers::TrashRemovedWidget(WBP, Widget);
 		FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
 		MarkRemoved();
 		RecordAffected(Ref);
@@ -373,6 +374,7 @@ void FClaireonDeltaApplicator_WidgetBP::Phase3CleanupOnFailure(const FString& Se
 		{
 			if (Tree->RootWidget == W) { Tree->RootWidget = nullptr; }
 			else { Tree->RemoveWidget(W); }
+			ClaireonWidgetHelpers::TrashRemovedWidget(WBP, W);
 		}
 	}
 	CreatedWidgetsThisCall.Reset();

--- a/Source/Claireon/Public/ClaireonWidgetHelpers.h
+++ b/Source/Claireon/Public/ClaireonWidgetHelpers.h
@@ -48,6 +48,27 @@ namespace ClaireonWidgetHelpers
 	/** Create a widget in a widget tree with RF_Transactional. */
 	UWidget* CreateWidget(UWidgetTree* Tree, TSubclassOf<UWidget> WidgetClass, FName WidgetName = NAME_None);
 
+	/**
+	 * Keep UWidgetBlueprint::WidgetVariableNameToGuidMap in sync with widget and
+	 * animation variable lifecycle. UE 5.8's widget compiler ensures every widget
+	 * and animation has a GUID entry; earlier engines have no such map, so these
+	 * are no-ops there. CreateWidget already notifies for the tree's owning
+	 * blueprint; call these directly for renames, removals, and objects created
+	 * outside CreateWidget (e.g. animations).
+	 */
+	void NotifyVariableAdded(UWidgetBlueprint* WidgetBP, FName VariableName);
+	void NotifyVariableRemoved(UWidgetBlueprint* WidgetBP, FName VariableName);
+	void NotifyVariableRenamed(UWidgetBlueprint* WidgetBP, FName OldName, FName NewName);
+
+	/**
+	 * Reparent a removed widget and its remaining children to the transient package
+	 * (the designer's delete pattern, see FWidgetBlueprintEditorUtils::DeleteWidgets)
+	 * so their names don't collide with future widgets and they stop counting as
+	 * source widgets, then drop their variable GUID entries. Call after the widget
+	 * has been detached from the tree.
+	 */
+	void TrashRemovedWidget(UWidgetBlueprint* WidgetBP, UWidget* Widget);
+
 	/** Add a child widget to a panel widget and configure slot properties. */
 	UPanelSlot* AddChildToPanel(UPanelWidget* Parent, UWidget* Child, const TSharedPtr<FJsonObject>& SlotProperties = nullptr);
 


### PR DESCRIPTION
## Summary

Makes Claireon compile and run on Unreal Engine 5.8 while preserving the existing code paths on earlier engines. All engine-version differences are gated with `UE_VERSION_OLDER_THAN(5, 8, 0)`, following the pattern already used for the 5.6 boundaries.

### 1. `FJsonObject` keys are `UE::FSharedString` in 5.8 (37 sites, 28 files)

5.8 changed `FJsonObject::Values` from `TMap<FString, ...>` to `TMap<UE::FSharedString, ...>`, so passing `Pair.Key` where `const FString&` is expected no longer compiles. Both `FString` and `UE::FSharedString` expose `operator*` returning `const TCHAR*`, so every affected site now uses `FString(*Pair.Key)` — no version guards needed; identical behavior on all engines.

### 2. StateTree binding API (5.8 removed the deprecated surface)

5.8 removed `FStateTreePropertyPath` and the `FStateTreeEditorPropertyBindings` entry points in favor of `FPropertyBindingPath` and the `FPropertyBindingBindingCollection` API. Added a `FClaireonPropertyPath` alias in `ClaireonStateTreeEditInternal.h` (mirroring the existing `FClaireonPropertyPathSegment` alias) and guarded the call sites:

| < 5.8 | >= 5.8 |
|---|---|
| `FStateTreePropertyPath` | `FPropertyBindingPath` |
| `AddPropertyBinding(Binding)` | `AddBinding(Source, Target)` |
| `RemovePropertyBindings(Path)` | `RemoveBindings(Path)` |
| `AddFunctionPropertyBinding(...)` | `AddFunctionBinding(...)` |

`#include "InstancedStruct.h"` in `ClaireonStateTreeHelpers.cpp` became `#include "StructUtils/InstancedStruct.h"` unconditionally (that path exists since 5.5 and is already used elsewhere in the codebase).

### 3. `UCameraAsset::BuildCamera` takes `FCameraBuildContext` in 5.8

The `BuildCamera(FCameraBuildLog&)` overload is gone; 5.8 wraps the same log in `UE::Cameras::FCameraBuildContext`. Guarded in both camera tools, following the 5.6 include guards already in those files.

### 4. `FChooserColumnBase::DeleteRows` takes `TArrayView<int>` in 5.8

`chooser_remove_row` previously passed `TArray<uint32>`; guarded to `TArray<int32>` on 5.8+.

### 5. Widget variable GUID bookkeeping (new in 5.8)

5.8's widget compiler validates that every widget and animation has an entry in `UWidgetBlueprint::WidgetVariableNameToGuidMap` (`WidgetBlueprintCompiler.cpp` `ValidateAndFixUpVariableGuids`: *"Widget [X] was added but did not get a GUID"* / *"Variable [X] was deleted but still has a GUID"*). The UMG designer maintains it via `UWidgetBlueprint::OnVariableAdded/OnVariableRenamed/OnVariableRemoved`; Claireon's tools did not, so widget/animation edits fired handled ensures at every compile.

Added `ClaireonWidgetHelpers::NotifyVariableAdded/Removed/Renamed` (no-ops before 5.8) and a `TrashRemovedWidget` helper, wired through:
- `ClaireonWidgetHelpers::CreateWidget` — covers add_widget, replace_widget, the spec applicator, and the delta applicator
- `ClaireonWidgetBPTool_Create` root widget (now routed through `CreateWidget`)
- `ClaireonWidgetBPTool_RemoveWidget` / `ClaireonWidgetBPTool_ReplaceWidget` / both delta-applicator removal paths
- `ClaireonWidgetBPTool_RenameWidget` (bookkeeping runs *before* `UObject::Rename`, which broadcasts and can trigger an immediate recompile)
- Animation create/delete/rename in `ClaireonWidgetAnimationHandlers` (same ordering rule)

Two subtleties found while verifying against a live 5.8 editor:

1. **Removed widgets must be reparented to the transient package**, exactly as `FWidgetBlueprintEditorUtils::DeleteWidgets` does. `UBaseWidgetBlueprint::ForEachSourceWidget` enumerates every `UWidget` outered to the WidgetTree (`ForEachObjectWithOuter`), not the live hierarchy — so a widget that is only detached still counts as a source widget, and 5.8's validation resurrects its GUID entry. The new `TrashRemovedWidget` also fixes a latent pre-5.8 name-collision bug when re-adding a widget with a deleted widget's name.
2. **Rename bookkeeping must precede the object rename** because `UObject::Rename` broadcasts and can recompile before the tool's next line runs.

### 6. `bp_compile` livelocks the editor on 5.8

`FKismetEditorUtilities::CompileBlueprint` with `EBlueprintCompileOptions::None` runs a synchronous `CollectGarbage` at the end of the compile; invoked from inside the MCP request handler on 5.8 this never returns (the editor saturates all cores; reproduced on plain and widget Blueprints; bisected against `SkipSave`, the `FCompilerResultsLog` argument, and the `BeginEvent` scope — the GC is the trigger, and the identical call completes in under a second when GC is skipped). The tool now passes `SkipSave | SkipGarbageCollection`:
- `SkipSave` matches the tool's documented contract ("compile is in-memory only; call bp_save to persist") and `UBlueprintEditorLibrary::CompileBlueprint`. Without it, users with Save-on-Compile enabled would get disk writes from a tool that promises not to write.
- `SkipGarbageCollection` defers GC to the editor's own cadence, which is safe for an interactive tool call.

## Testing

Built and exercised against a 5.8 engine via the live MCP server in a real project:

- `camera_asset_compile` on a real `UCameraAsset` — build log captured, no errors
- `chooser_remove_row` — row removed, counts verified
- Full StateTree session: `add_state`, `add_task` with properties, `add_binding`, `remove_binding`, `add_property_function` (`StateTreeAddFloatPropertyFunction`), `statetree_compile` (succeeded), `statetree_save`
- `datatable_set_row_values`, `material_add_expression` with `initial_properties`, `widgetbp_add_widget` with `slot_properties`, `anim_add_notify` with `properties`, `level_place_actor` with `properties`
- Widget lifecycle (add → rename → remove, plus animation create/rename/delete) verified with direct reads of `WidgetVariableNameToGuidMap` after each step: the map stays exactly in sync and the full editor session log contains zero ensures
- `bp_compile` on both a plain Blueprint and a WidgetBlueprint completes in under a second (both previously hung the editor indefinitely)

Pre-5.8 engines were **not** rebuilt as part of this change; the guarded `< 5.8` branches preserve the existing upstream code verbatim, and the unguarded `FString(*Key)` form compiles against both key types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
