### PR TITLE
UE 5.8 support, version-gated: reconciliation of #8 and #9

### DIFF
--- a/Source/Claireon/Claireon.Build.cs
+++ b/Source/Claireon/Claireon.Build.cs
@@ -30,7 +30,6 @@ public class Claireon : ModuleRules
 			"JsonUtilities",
 			"AssetRegistry",
 			"InputCore",
-			"PythonScriptPlugin",
 			"WorkspaceMenuStructure",
 
 			// Blueprint editing tools dependencies
@@ -139,6 +138,22 @@ public class Claireon : ModuleRules
 			"MetasoundFrontend", // FMetaSoundFrontendDocumentBuilder + Metasound::Frontend graph handle API
 
 		});
+
+		// PythonScriptPlugin: UE 5.8 ships it as a runtime module with NO import .lib in installed
+		// builds, so it cannot be statically linked there. Claireon only touches it via the inline
+		// IPythonScriptPlugin::Get() accessor + virtual calls + header-only FPythonCommandEx, so on
+		// 5.8+ take its public include paths and load it dynamically instead of linking. Earlier
+		// engines keep the static dependency (unchanged behavior). (Python3 C-API stays a normal
+		// dependency for the bridge, above.)
+		if (Target.Version.MajorVersion > 5 || (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8))
+		{
+			PrivateIncludePathModuleNames.Add("PythonScriptPlugin");
+			DynamicallyLoadedModuleNames.Add("PythonScriptPlugin");
+		}
+		else
+		{
+			PrivateDependencyModuleNames.Add("PythonScriptPlugin");
+		}
 
 		// UE 5.7 moved these headers into module Internal/ dirs, which UBT doesn't expose to
 		// external plugins. Owning modules are already linked; just add the Internal/ paths.

--- a/Source/Claireon/Private/ClaireonBPTranslateSession.cpp
+++ b/Source/Claireon/Private/ClaireonBPTranslateSession.cpp
@@ -129,11 +129,11 @@ FClaireonBPTranslateSession FClaireonBPTranslateSession::LoadFromFile(const FStr
 					NodeStatus.Status = NodeObj->GetStringField(TEXT("status"));
 					NodeStatus.Type = NodeObj->GetStringField(TEXT("type"));
 					NodeStatus.Name = NodeObj->GetStringField(TEXT("name"));
-					BPState.Nodes.Add(NodePair.Key, NodeStatus);
+					BPState.Nodes.Add(FString(*NodePair.Key), NodeStatus);
 				}
 			}
 
-			Session.Blueprints.Add(BPPair.Key, BPState);
+			Session.Blueprints.Add(FString(*BPPair.Key), BPState);
 		}
 	}
 

--- a/Source/Claireon/Private/ClaireonBlueprintHelpers.cpp
+++ b/Source/Claireon/Private/ClaireonBlueprintHelpers.cpp
@@ -1179,6 +1179,10 @@ namespace ClaireonBlueprintHelpers
 			return;
 		}
 
+		// Deleting the .uasset on disk above does not evict a same-named object still loaded in
+		// memory; UE 5.8 CreateBlueprint asserts the name is free, so clear it first.
+		ClaireonAssetUtils::EvictInMemoryObject(Package, AssetName);
+
 		UBlueprint* BP = FKismetEditorUtilities::CreateBlueprint(
 			ParentClass, Package, FName(*AssetName),
 			BPTYPE_Normal,

--- a/Source/Claireon/Private/ClaireonBridge.cpp
+++ b/Source/Claireon/Private/ClaireonBridge.cpp
@@ -999,11 +999,22 @@ bool FClaireonBridge::EnsureNoLeakedWorlds(TArray<FClaireonLeakedWorld>& OutRema
 	UPackage* EditorWorldPackage = EditorWorld ? EditorWorld->GetOutermost() : nullptr;
 
 	// Walk every loaded World and decide skip vs. candidate-for-unload.
+	// Exclude Unreachable/Garbage objects: this runs immediately after a GC
+	// pass, and the default iterator would otherwise hand back worlds that GC
+	// has marked for teardown but not yet purged -- dereferencing their (now
+	// dangling) FName in GetName() faults in FName::ToString().
+	//
+	// Names are captured separately: the raw pointers feed UnloadPackages
+	// below, but CollectGarbage may free the packages, so nothing after
+	// the GC call may dereference NonDirtyCandidates entries.
 	TArray<UPackage*> NonDirtyCandidates;
-	for (TObjectIterator<UWorld> It; It; ++It)
+	TArray<FString> NonDirtyCandidateNames;
+	for (TObjectIterator<UWorld> It(RF_ClassDefaultObject, /*bIncludeDerivedClasses=*/true,
+		EInternalObjectFlags::Unreachable | EInternalObjectFlags::Garbage); It; ++It)
 	{
 		UWorld* W = *It;
-		if (!W) { continue; }
+		if (!ensureMsgf(IsValid(W),
+			TEXT("[MCP Guard] Object iterator yielded an invalid UWorld post-GC; skipping"))) { continue; }
 
 		// Skip editor world.
 		if (W == EditorWorld) { continue; }
@@ -1025,6 +1036,12 @@ bool FClaireonBridge::EnsureNoLeakedWorlds(TArray<FClaireonLeakedWorld>& OutRema
 		// Skip transient Worlds (parity with EditorServer.cpp Map_Load).
 		if (WP == GetTransientPackage() || !WP) { continue; }
 
+		// Guard the outer package too: a world can survive the IsValid(W)
+		// check while its outermost is mid-teardown, and GetName() below
+		// would then fault in FName::ToString().
+		if (!ensureMsgf(IsValid(WP),
+			TEXT("[MCP Guard] UWorld has an invalid outer package post-GC; skipping"))) { continue; }
+
 		// Candidate.
 		FClaireonLeakedWorld Entry;
 		Entry.PackageName = WP->GetName();
@@ -1040,6 +1057,7 @@ bool FClaireonBridge::EnsureNoLeakedWorlds(TArray<FClaireonLeakedWorld>& OutRema
 
 		Entry.bUnloadAttempted = true;
 		NonDirtyCandidates.Add(WP);
+		NonDirtyCandidateNames.Add(Entry.PackageName);
 		UE_LOG(LogClaireon, Warning,
 			TEXT("[MCP Guard] Leaked World detected, attempting unload: %s"),
 			*Entry.PackageName);
@@ -1074,10 +1092,12 @@ bool FClaireonBridge::EnsureNoLeakedWorlds(TArray<FClaireonLeakedWorld>& OutRema
 	// by another reference).
 	{
 		TSet<FString> StillLoadedNames;
-		for (TObjectIterator<UWorld> It; It; ++It)
+		for (TObjectIterator<UWorld> It(RF_ClassDefaultObject, /*bIncludeDerivedClasses=*/true,
+			EInternalObjectFlags::Unreachable | EInternalObjectFlags::Garbage); It; ++It)
 		{
 			UWorld* W = *It;
-			if (!W) { continue; }
+			if (!ensureMsgf(IsValid(W),
+				TEXT("[MCP Guard] Object iterator yielded an invalid UWorld post-GC; skipping"))) { continue; }
 			if (W == EditorWorld) { continue; }
 			const EWorldType::Type Type = W->WorldType;
 			if (Type == EWorldType::PIE
@@ -1085,13 +1105,13 @@ bool FClaireonBridge::EnsureNoLeakedWorlds(TArray<FClaireonLeakedWorld>& OutRema
 				|| Type == EWorldType::EditorPreview) { continue; }
 			UPackage* WP = W->GetOutermost();
 			if (!WP || WP == EditorWorldPackage || WP == GetTransientPackage()) { continue; }
+			if (!ensureMsgf(IsValid(WP),
+				TEXT("[MCP Guard] UWorld has an invalid outer package post-GC; skipping"))) { continue; }
 			StillLoadedNames.Add(WP->GetName());
 		}
 
-		for (UPackage* WP : NonDirtyCandidates)
+		for (const FString& PackageName : NonDirtyCandidateNames)
 		{
-			if (!WP) { continue; }
-			const FString PackageName = WP->GetName();
 			if (StillLoadedNames.Contains(PackageName))
 			{
 				FClaireonLeakedWorld Entry;

--- a/Source/Claireon/Private/ClaireonBridge.cpp
+++ b/Source/Claireon/Private/ClaireonBridge.cpp
@@ -608,7 +608,10 @@ void FClaireonBridge::BuildAndRunBootstrap()
 			const TSharedPtr<FJsonObject>* PropertiesObj = nullptr;
 			if (Schema->TryGetObjectField(TEXT("properties"), PropertiesObj))
 			{
-				(*PropertiesObj)->Values.GetKeys(PropertyNames);
+				for (const auto& PropPair : (*PropertiesObj)->Values)
+				{
+					PropertyNames.Add(FString(*PropPair.Key));
+				}
 			}
 
 			// Build this tool's JSON entry

--- a/Source/Claireon/Private/ClaireonGasToolCommon.cpp
+++ b/Source/Claireon/Private/ClaireonGasToolCommon.cpp
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#include "ClaireonGasToolCommon.h"
+
+#include "ClaireonPIEManager.h"
+#include "ClaireonPIEWorldResolver.h"
+
+#include "AbilitySystemComponent.h"
+#include "AbilitySystemGlobals.h"
+#include "AbilitySystemInterface.h"
+#include "AttributeSet.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Editor.h"
+#include "GameFramework/Actor.h"
+#include "GameplayEffect.h"
+#include "Abilities/GameplayAbility.h"
+#include "UObject/UObjectIterator.h"
+
+namespace ClaireonGasToolCommonInternal
+{
+	// Skeleton / reinstanced / trashed transient UClasses that must never be
+	// offered as a name match.
+	static bool IsTransientClass(const UClass* Class)
+	{
+		const FString Name = Class->GetName();
+		return Name.StartsWith(TEXT("SKEL_"))
+			|| Name.StartsWith(TEXT("REINST_"))
+			|| Name.StartsWith(TEXT("TRASHCLASS"))
+			|| Name.Contains(TEXT("HOTRELOADED_"));
+	}
+
+	// Shared name/path resolver for the two class-typed params. `PathField` and
+	// `NameField` name the two accepted arguments; `Base` bounds the search.
+	static UClass* ResolveClassByPathOrName(
+		const TSharedPtr<FJsonObject>& Arguments,
+		const TCHAR* PathField,
+		const TCHAR* NameField,
+		UClass* Base,
+		FString& OutError)
+	{
+		FString ClassPath;
+		if (Arguments->TryGetStringField(PathField, ClassPath) && !ClassPath.IsEmpty())
+		{
+			UClass* Loaded = LoadClass<UObject>(nullptr, *ClassPath);
+			if (!Loaded)
+			{
+				OutError = FString::Printf(
+					TEXT("Could not load a class from %s='%s'. Expected a generated-class path "
+						 "ending in '_C' (e.g. '/Game/.../GE_X.GE_X_C')."),
+					PathField, *ClassPath);
+				return nullptr;
+			}
+			if (!Loaded->IsChildOf(Base))
+			{
+				OutError = FString::Printf(TEXT("Class '%s' is not a %s subclass."),
+					*ClassPath, *Base->GetName());
+				return nullptr;
+			}
+			return Loaded;
+		}
+
+		FString ClassName;
+		if (Arguments->TryGetStringField(NameField, ClassName) && !ClassName.IsEmpty())
+		{
+			TArray<UClass*> Matches;
+			for (TObjectIterator<UClass> It; It; ++It)
+			{
+				UClass* Candidate = *It;
+				if (Candidate == Base || !Candidate->IsChildOf(Base)) { continue; }
+				if (IsTransientClass(Candidate)) { continue; }
+				if (Candidate->GetName().Contains(ClassName, ESearchCase::IgnoreCase))
+				{
+					Matches.AddUnique(Candidate);
+				}
+			}
+			if (Matches.Num() == 0)
+			{
+				OutError = FString::Printf(
+					TEXT("No loaded %s subclass matches %s='%s'. Load the asset first or pass "
+						 "the authoritative class path instead."),
+					*Base->GetName(), NameField, *ClassName);
+				return nullptr;
+			}
+			if (Matches.Num() > 1)
+			{
+				FString Names;
+				for (const UClass* M : Matches)
+				{
+					Names += (Names.IsEmpty() ? TEXT("") : TEXT(", "));
+					Names += M->GetName();
+				}
+				OutError = FString::Printf(
+					TEXT("%s='%s' is ambiguous (%d matches: %s). Pass a class path instead."),
+					NameField, *ClassName, Matches.Num(), *Names);
+				return nullptr;
+			}
+			return Matches[0];
+		}
+
+		OutError = FString::Printf(TEXT("Provide either %s or %s."), PathField, NameField);
+		return nullptr;
+	}
+}
+
+using namespace ClaireonGasToolCommonInternal;
+
+namespace ClaireonGasToolCommon
+{
+
+void AddCommonSchemaParams(const TSharedPtr<FJsonObject>& Properties)
+{
+	if (!Properties.IsValid())
+	{
+		return;
+	}
+
+	TSharedPtr<FJsonObject> ActorIdProp = MakeShared<FJsonObject>();
+	ActorIdProp->SetStringField(TEXT("type"), TEXT("string"));
+	ActorIdProp->SetStringField(TEXT("description"),
+		TEXT("Stable actor ID (e.g. 'actor_0') minted by pie_get_player_pawn / pie_get_actor. "
+			 "Actor IDs are per-world: an ID minted on the client world will not resolve on the "
+			 "server world, so re-resolve on the world you target with net_mode."));
+	Properties->SetObjectField(TEXT("actorId"), ActorIdProp);
+
+	// pie_instance + net_mode.
+	ClaireonPIEWorldResolver::AddSchemaParams(Properties);
+}
+
+bool ResolveTarget(const TSharedPtr<FJsonObject>& Arguments, FGasTarget& OutTarget, FString& OutError)
+{
+	OutTarget = FGasTarget();
+
+	if (!Arguments.IsValid())
+	{
+		OutError = TEXT("Missing arguments.");
+		return false;
+	}
+
+	FString ActorId;
+	if (!Arguments->TryGetStringField(TEXT("actorId"), ActorId) || ActorId.IsEmpty())
+	{
+		OutError = TEXT("Missing required argument: actorId");
+		return false;
+	}
+
+	if (!GEditor || !GEditor->IsPlaySessionInProgress())
+	{
+		OutError = TEXT("No active PIE session. Start Play-in-Editor first (these tools mutate/read "
+			"live runtime GAS state, not on-disk assets).");
+		return false;
+	}
+
+	// GAS is authority-driven: default to the server world when the caller did
+	// not specify a role, so mutations replicate and inspection reads truth.
+	if (!Arguments->HasField(TEXT("net_mode")))
+	{
+		Arguments->SetStringField(TEXT("net_mode"), TEXT("server"));
+	}
+
+	UWorld* World = ClaireonPIEWorldResolver::ResolvePIEWorld(Arguments, OutError);
+	if (!World)
+	{
+		return false;
+	}
+	OutTarget.World = World;
+
+	AActor* Actor = FClaireonPIEManager::Get().ResolveActorId(ActorId, World);
+	if (!Actor)
+	{
+		OutError = FString::Printf(
+			TEXT("Actor not found for ID '%s' on the resolved world. Actor IDs are per-world; "
+				 "re-resolve the actor on the world you target with net_mode."), *ActorId);
+		return false;
+	}
+	OutTarget.Actor = Actor;
+
+	UAbilitySystemComponent* ASC = nullptr;
+	if (IAbilitySystemInterface* ASCInterface = Cast<IAbilitySystemInterface>(Actor))
+	{
+		ASC = ASCInterface->GetAbilitySystemComponent();
+	}
+	if (!ASC)
+	{
+		ASC = UAbilitySystemGlobals::GetAbilitySystemComponentFromActor(Actor);
+	}
+	if (!ASC)
+	{
+		OutError = FString::Printf(
+			TEXT("Actor '%s' (%s) has no AbilitySystemComponent."),
+			*Actor->GetName(), *ActorId);
+		return false;
+	}
+	OutTarget.ASC = ASC;
+
+	return true;
+}
+
+TSubclassOf<UGameplayEffect> ResolveEffectClass(const TSharedPtr<FJsonObject>& Arguments, FString& OutError)
+{
+	UClass* Resolved = ResolveClassByPathOrName(
+		Arguments, TEXT("effect_class_path"), TEXT("effect_name"),
+		UGameplayEffect::StaticClass(), OutError);
+	return Resolved ? TSubclassOf<UGameplayEffect>(Resolved) : nullptr;
+}
+
+TSubclassOf<UGameplayAbility> ResolveAbilityClass(const TSharedPtr<FJsonObject>& Arguments, FString& OutError)
+{
+	UClass* Resolved = ResolveClassByPathOrName(
+		Arguments, TEXT("ability_class_path"), TEXT("ability_name"),
+		UGameplayAbility::StaticClass(), OutError);
+	return Resolved ? TSubclassOf<UGameplayAbility>(Resolved) : nullptr;
+}
+
+bool ResolveAttribute(UAbilitySystemComponent* ASC, const FString& Name, FGameplayAttribute& OutAttr, FString& OutError)
+{
+	if (!ASC)
+	{
+		OutError = TEXT("No AbilitySystemComponent.");
+		return false;
+	}
+	if (Name.IsEmpty())
+	{
+		OutError = TEXT("Missing required argument: attribute");
+		return false;
+	}
+
+	TArray<FGameplayAttribute> Attributes;
+	ASC->GetAllAttributes(Attributes);
+
+	// Exact (case-insensitive) name match wins outright.
+	for (const FGameplayAttribute& Attr : Attributes)
+	{
+		if (Attr.GetName().Equals(Name, ESearchCase::IgnoreCase))
+		{
+			OutAttr = Attr;
+			return true;
+		}
+	}
+
+	// Otherwise a unique substring match.
+	TArray<FGameplayAttribute> Partial;
+	for (const FGameplayAttribute& Attr : Attributes)
+	{
+		if (Attr.GetName().Contains(Name, ESearchCase::IgnoreCase))
+		{
+			Partial.Add(Attr);
+		}
+	}
+	if (Partial.Num() == 1)
+	{
+		OutAttr = Partial[0];
+		return true;
+	}
+	if (Partial.Num() > 1)
+	{
+		FString Names;
+		for (const FGameplayAttribute& Attr : Partial)
+		{
+			Names += (Names.IsEmpty() ? TEXT("") : TEXT(", "));
+			Names += AttributeDisplayName(Attr);
+		}
+		OutError = FString::Printf(TEXT("Attribute '%s' is ambiguous (%d matches: %s)."),
+			*Name, Partial.Num(), *Names);
+		return false;
+	}
+
+	OutError = FString::Printf(TEXT("No attribute matching '%s' on this ASC."), *Name);
+	return false;
+}
+
+FString AttributeDisplayName(const FGameplayAttribute& Attr)
+{
+	const UClass* SetClass = Attr.GetAttributeSetClass();
+	if (SetClass)
+	{
+		return FString::Printf(TEXT("%s.%s"), *SetClass->GetName(), *Attr.GetName());
+	}
+	return Attr.GetName();
+}
+
+} // namespace ClaireonGasToolCommon

--- a/Source/Claireon/Private/ClaireonGasToolCommon.h
+++ b/Source/Claireon/Private/ClaireonGasToolCommon.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Templates/SubclassOf.h"
+
+class FJsonObject;
+class UWorld;
+class AActor;
+class UAbilitySystemComponent;
+class UGameplayEffect;
+class UGameplayAbility;
+struct FGameplayAttribute;
+
+/**
+ * Shared plumbing for the runtime GAS tools (gas_runtime_inspect / gas_apply_effect /
+ * gas_remove_effect / gas_grant_ability / gas_activate_ability / gas_set_tags /
+ * gas_set_attribute).
+ *
+ * Engine GAS API only -- no dependency on FSGame or any Fellowship module, so
+ * the whole gas_* changeset stays a Claireon-only PR (see
+ * CLAIREON-GAS-TOOLS-SPEC.md section 1). Target resolution goes through
+ * ClaireonPIEWorldResolver so client-side actors are reachable; GAS is
+ * authority-driven, so absent an explicit net_mode these tools default to the
+ * server world (the authoritative ASC).
+ */
+namespace ClaireonGasToolCommon
+{
+	/** Resolved runtime target: the PIE world, the actor, and its ASC. */
+	struct FGasTarget
+	{
+		UWorld* World = nullptr;
+		AActor* Actor = nullptr;
+		UAbilitySystemComponent* ASC = nullptr;
+	};
+
+	/**
+	 * Add the shared input-schema properties every gas_* tool exposes: the
+	 * required `actorId` string plus ClaireonPIEWorldResolver's pie_instance /
+	 * net_mode params. Does NOT populate the schema's "required" array -- each
+	 * tool owns that (all require actorId; some add more).
+	 */
+	void AddCommonSchemaParams(const TSharedPtr<FJsonObject>& Properties);
+
+	/**
+	 * Resolve the target ASC from tool arguments. Guards that PIE is running,
+	 * defaults net_mode to "server" when the caller omitted it (authoritative
+	 * ASC), resolves the world via ClaireonPIEWorldResolver, resolves actorId
+	 * via FClaireonPIEManager, and fetches the ASC (IAbilitySystemInterface,
+	 * falling back to UAbilitySystemGlobals). Returns false with OutError set on
+	 * any failure. NOTE: may add a default "net_mode" field to Arguments.
+	 */
+	bool ResolveTarget(const TSharedPtr<FJsonObject>& Arguments, FGasTarget& OutTarget, FString& OutError);
+
+	/**
+	 * Resolve a UGameplayEffect subclass from either `effect_class_path`
+	 * (authoritative, e.g. "/Game/.../GE_X.GE_X_C") or `effect_name` (substring
+	 * match against loaded UGameplayEffect subclasses; errors if ambiguous or
+	 * not loaded). Returns nullptr with OutError set on failure.
+	 */
+	TSubclassOf<UGameplayEffect> ResolveEffectClass(const TSharedPtr<FJsonObject>& Arguments, FString& OutError);
+
+	/**
+	 * Resolve a UGameplayAbility subclass from `ability_class_path` or
+	 * `ability_name` (same rules as ResolveEffectClass). Returns nullptr with
+	 * OutError set on failure.
+	 */
+	TSubclassOf<UGameplayAbility> ResolveAbilityClass(const TSharedPtr<FJsonObject>& Arguments, FString& OutError);
+
+	/**
+	 * Match a (possibly partial) attribute name against the ASC's attribute
+	 * list. Prefers an exact case-insensitive name match, then a unique
+	 * substring match. Returns false with OutError set when nothing matches or
+	 * the substring is ambiguous.
+	 */
+	bool ResolveAttribute(UAbilitySystemComponent* ASC, const FString& Name, FGameplayAttribute& OutAttr, FString& OutError);
+
+	/** Human-facing "Set.Name" label for an attribute (Set omitted if unknown). */
+	FString AttributeDisplayName(const FGameplayAttribute& Attr);
+}

--- a/Source/Claireon/Private/ClaireonModule.cpp
+++ b/Source/Claireon/Private/ClaireonModule.cpp
@@ -147,6 +147,14 @@
 #include "Tools/ClaireonTool_PIEUnregisterDamageListener.h"
 #include "Tools/ClaireonTool_PIEAITargetInfo.h"
 #include "Tools/ClaireonTool_PIETestAbility.h"
+// Runtime GAS tools (engine GAS API only -- no FSGame dependency).
+#include "Tools/ClaireonTool_GasInspect.h"
+#include "Tools/ClaireonTool_GasApplyEffect.h"
+#include "Tools/ClaireonTool_GasRemoveEffect.h"
+#include "Tools/ClaireonTool_GasGrantAbility.h"
+#include "Tools/ClaireonTool_GasActivateAbility.h"
+#include "Tools/ClaireonTool_GasSetTags.h"
+#include "Tools/ClaireonTool_GasSetAttribute.h"
 #include "Tools/ClaireonTool_ConsoleExecute.h"
 #include "Tools/ClaireonTool_AssetList.h"
 #include "Tools/ClaireonTool_AssetValidate.h"
@@ -1401,6 +1409,14 @@ TArray<TSharedPtr<IClaireonTool>> FClaireonBuiltinToolProvider::GetTools() const
 	Tools.Add(MakeShared<ClaireonTool_PIEUnregisterDamageListener>());
 	Tools.Add(MakeShared<ClaireonTool_PIEAITargetInfo>());
 	Tools.Add(MakeShared<ClaireonTool_PIETestAbility>());
+	// Runtime GAS inspection + mutation (grant/apply on the authoritative ASC).
+	Tools.Add(MakeShared<ClaireonTool_GasInspect>());
+	Tools.Add(MakeShared<ClaireonTool_GasApplyEffect>());
+	Tools.Add(MakeShared<ClaireonTool_GasRemoveEffect>());
+	Tools.Add(MakeShared<ClaireonTool_GasGrantAbility>());
+	Tools.Add(MakeShared<ClaireonTool_GasActivateAbility>());
+	Tools.Add(MakeShared<ClaireonTool_GasSetTags>());
+	Tools.Add(MakeShared<ClaireonTool_GasSetAttribute>());
 	// Flythrough camera tools
 	Tools.Add(MakeShared<ClaireonTool_FlythroughStart>());
 	Tools.Add(MakeShared<ClaireonTool_FlythroughStop>());

--- a/Source/Claireon/Private/ClaireonPIEWorldResolver.cpp
+++ b/Source/Claireon/Private/ClaireonPIEWorldResolver.cpp
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#include "ClaireonPIEWorldResolver.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+#include "UObject/WeakObjectPtr.h"
+
+namespace ClaireonPIEWorldResolverInternal
+{
+	// Named file-local namespace (NOT a raw anonymous namespace): under
+	// linux-build-server-v2 unity batching, anonymous namespaces from separate
+	// .cpp merge into one TU and collide -- a named namespace is the isolation.
+	TWeakObjectPtr<UWorld> GClaireonPIEWorldResolver_TestOverrideWorld;
+
+	FString ClaireonPIEWorldResolver_DescribeCandidates(TArrayView<const ClaireonPIEWorldResolver::FPIEContextCandidate> Candidates)
+	{
+		TArray<FString> Parts;
+		for (const ClaireonPIEWorldResolver::FPIEContextCandidate& Candidate : Candidates)
+		{
+			if (!Candidate.bHasWorld)
+			{
+				continue;
+			}
+			FString Role;
+			if (Candidate.bIsServer && Candidate.bIsClient)
+			{
+				Role = TEXT("standalone");
+			}
+			else if (Candidate.bIsServer)
+			{
+				Role = TEXT("server");
+			}
+			else if (Candidate.bIsClient)
+			{
+				Role = TEXT("client");
+			}
+			else
+			{
+				Role = TEXT("unknown");
+			}
+			Parts.Add(FString::Printf(TEXT("instance %d (%s)"), Candidate.PIEInstance, *Role));
+		}
+		return Parts.Num() > 0 ? FString::Join(Parts, TEXT(", ")) : FString(TEXT("none"));
+	}
+} // namespace ClaireonPIEWorldResolverInternal
+
+using namespace ClaireonPIEWorldResolverInternal;
+
+namespace ClaireonPIEWorldResolver
+{
+
+bool ParseRequest(const TSharedPtr<FJsonObject>& Arguments, FPIEWorldRequest& OutRequest, FString& OutError)
+{
+	OutRequest = FPIEWorldRequest();
+
+	if (!Arguments.IsValid())
+	{
+		return true;
+	}
+
+	if (Arguments->HasField(TEXT("pie_instance")))
+	{
+		if (!Arguments->HasTypedField<EJson::Number>(TEXT("pie_instance")))
+		{
+			OutError = TEXT("Invalid pie_instance: expected an integer.");
+			return false;
+		}
+		OutRequest.PIEInstance = static_cast<int32>(Arguments->GetNumberField(TEXT("pie_instance")));
+	}
+
+	FString NetModeValue;
+	if (Arguments->TryGetStringField(TEXT("net_mode"), NetModeValue) && !NetModeValue.IsEmpty())
+	{
+		const FString NetModeLower = NetModeValue.ToLower();
+		if (NetModeLower != TEXT("server") && NetModeLower != TEXT("client"))
+		{
+			OutError = FString::Printf(
+				TEXT("Invalid net_mode '%s'. Valid values: 'server', 'client'."), *NetModeValue);
+			return false;
+		}
+		OutRequest.NetMode = NetModeLower;
+	}
+
+	return true;
+}
+
+int32 SelectPIEContextIndex(TArrayView<const FPIEContextCandidate> Candidates, const FPIEWorldRequest& Request, FString& OutError)
+{
+	TArray<int32> Surviving;
+	for (int32 Index = 0; Index < Candidates.Num(); ++Index)
+	{
+		if (Candidates[Index].bHasWorld)
+		{
+			Surviving.Add(Index);
+		}
+	}
+
+	if (Surviving.Num() == 0)
+	{
+		OutError = TEXT("No active PIE session. Start Play-in-Editor first.");
+		return INDEX_NONE;
+	}
+
+	if (Request.PIEInstance.IsSet())
+	{
+		const int32 WantedInstance = Request.PIEInstance.GetValue();
+		TArray<int32> InstanceMatched;
+		for (int32 Index : Surviving)
+		{
+			if (Candidates[Index].PIEInstance == WantedInstance)
+			{
+				InstanceMatched.Add(Index);
+			}
+		}
+		if (InstanceMatched.Num() == 0)
+		{
+			OutError = FString::Printf(
+				TEXT("No PIE world context matched pie_instance=%d. Available PIE contexts: %s."),
+				WantedInstance,
+				*ClaireonPIEWorldResolver_DescribeCandidates(Candidates));
+			return INDEX_NONE;
+		}
+		Surviving = MoveTemp(InstanceMatched);
+	}
+
+	if (Request.NetMode.IsSet())
+	{
+		const bool bWantServer = Request.NetMode.GetValue() == TEXT("server");
+		TArray<int32> RoleMatched;
+		for (int32 Index : Surviving)
+		{
+			const FPIEContextCandidate& Candidate = Candidates[Index];
+			if ((bWantServer && Candidate.bIsServer) || (!bWantServer && Candidate.bIsClient))
+			{
+				RoleMatched.Add(Index);
+			}
+		}
+		if (RoleMatched.Num() == 0)
+		{
+			OutError = FString::Printf(
+				TEXT("No PIE world context matched net_mode='%s'. Available PIE contexts: %s."),
+				*Request.NetMode.GetValue(),
+				*ClaireonPIEWorldResolver_DescribeCandidates(Candidates));
+			return INDEX_NONE;
+		}
+		Surviving = MoveTemp(RoleMatched);
+	}
+
+	return Surviving[0];
+}
+
+UWorld* ResolvePIEWorld(const TSharedPtr<FJsonObject>& Arguments, FString& OutError)
+{
+	if (UWorld* OverrideWorld = GClaireonPIEWorldResolver_TestOverrideWorld.Get())
+	{
+		return OverrideWorld;
+	}
+
+	FPIEWorldRequest Request;
+	if (!ParseRequest(Arguments, Request, OutError))
+	{
+		return nullptr;
+	}
+
+	if (!GEngine)
+	{
+		OutError = TEXT("GEngine is not available; cannot enumerate PIE world contexts.");
+		return nullptr;
+	}
+
+	TArray<FPIEContextCandidate> Candidates;
+	TArray<UWorld*> CandidateWorlds;
+	for (const FWorldContext& WorldContext : GEngine->GetWorldContexts())
+	{
+		if (WorldContext.WorldType != EWorldType::PIE)
+		{
+			continue;
+		}
+
+		FPIEContextCandidate Candidate;
+		Candidate.PIEInstance = WorldContext.PIEInstance;
+
+		UWorld* ContextWorld = WorldContext.World();
+		Candidate.bHasWorld = (ContextWorld != nullptr);
+		if (ContextWorld)
+		{
+			const ENetMode NetMode = ContextWorld->GetNetMode();
+			// A standalone PIE world is both the authority and the local
+			// client, so it satisfies either net_mode filter.
+			Candidate.bIsServer =
+				NetMode == NM_DedicatedServer || NetMode == NM_ListenServer || NetMode == NM_Standalone;
+			Candidate.bIsClient = NetMode == NM_Client || NetMode == NM_Standalone;
+		}
+
+		Candidates.Add(Candidate);
+		CandidateWorlds.Add(ContextWorld);
+	}
+
+	const int32 SelectedIndex = SelectPIEContextIndex(Candidates, Request, OutError);
+	if (SelectedIndex == INDEX_NONE)
+	{
+		return nullptr;
+	}
+
+	return CandidateWorlds[SelectedIndex];
+}
+
+void AddSchemaParams(const TSharedPtr<FJsonObject>& Properties)
+{
+	if (!Properties.IsValid())
+	{
+		return;
+	}
+
+	TSharedPtr<FJsonObject> PieInstanceProp = MakeShared<FJsonObject>();
+	PieInstanceProp->SetStringField(TEXT("type"), TEXT("integer"));
+	PieInstanceProp->SetStringField(TEXT("description"),
+		TEXT("Optional PIE instance index to target when multiple PIE world contexts exist "
+			 "(multi-client PIE). Default: the first PIE context (historical behavior)."));
+	Properties->SetObjectField(TEXT("pie_instance"), PieInstanceProp);
+
+	TSharedPtr<FJsonObject> NetModeProp = MakeShared<FJsonObject>();
+	NetModeProp->SetStringField(TEXT("type"), TEXT("string"));
+	NetModeProp->SetStringField(TEXT("description"),
+		TEXT("Optional network role of the PIE world to target: 'server' picks the authority world, "
+			 "'client' picks a client world (required to reach client-side actors under Play-as-Client). "
+			 "A standalone (non-networked) PIE world satisfies either value. "
+			 "Default: the first PIE context, which under Play-as-Client is the server world."));
+	TArray<TSharedPtr<FJsonValue>> NetModeEnum;
+	NetModeEnum.Add(MakeShared<FJsonValueString>(TEXT("server")));
+	NetModeEnum.Add(MakeShared<FJsonValueString>(TEXT("client")));
+	NetModeProp->SetArrayField(TEXT("enum"), NetModeEnum);
+	Properties->SetObjectField(TEXT("net_mode"), NetModeProp);
+}
+
+void SetPIEWorldOverrideForTesting(UWorld* World)
+{
+	GClaireonPIEWorldResolver_TestOverrideWorld = World;
+}
+
+} // namespace ClaireonPIEWorldResolver

--- a/Source/Claireon/Private/ClaireonPIEWorldResolver.h
+++ b/Source/Claireon/Private/ClaireonPIEWorldResolver.h
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Containers/ArrayView.h"
+#include "Misc/Optional.h"
+#include "Templates/SharedPointer.h"
+
+class FJsonObject;
+class UWorld;
+
+/**
+ * Shared PIE world resolution for MCP tools (WI-13).
+ *
+ * Historically every PIE-facing tool picked the FIRST WorldType==PIE context
+ * in GEngine->GetWorldContexts(). Under Play-as-Client that is always the
+ * server world, making client-side actors unreachable. This helper honors two
+ * optional schema parameters:
+ *
+ *   - pie_instance (integer): target a specific PIE instance index when
+ *     multiple PIE world contexts exist (multi-client PIE).
+ *   - net_mode ('server' or 'client'): target the world by network role.
+ *
+ * With neither parameter provided, the first live PIE context is returned,
+ * preserving the historical default behavior.
+ */
+namespace ClaireonPIEWorldResolver
+{
+	/** Caller request parsed from tool arguments. Unset fields mean "no filter". */
+	struct FPIEWorldRequest
+	{
+		TOptional<int32> PIEInstance;
+
+		// Validated by ParseRequest to be exactly "server" or "client".
+		TOptional<FString> NetMode;
+	};
+
+	/**
+	 * A lightweight, engine-independent view of one PIE world context, used so
+	 * the selection logic can be unit-tested against fabricated context arrays
+	 * without creating real UWorlds.
+	 */
+	struct FPIEContextCandidate
+	{
+		int32 PIEInstance = INDEX_NONE;
+		bool bHasWorld = false;
+		bool bIsServer = false;
+		bool bIsClient = false;
+	};
+
+	/**
+	 * Parse the optional 'pie_instance' and 'net_mode' fields from tool
+	 * arguments. Returns false with OutError set when a provided value is
+	 * malformed (wrong JSON type, or net_mode outside 'server'/'client').
+	 * A null/absent Arguments object parses to an empty request.
+	 */
+	bool ParseRequest(const TSharedPtr<FJsonObject>& Arguments, FPIEWorldRequest& OutRequest, FString& OutError);
+
+	/**
+	 * Pure selection core: pick the index of the candidate matching Request,
+	 * or INDEX_NONE with OutError set (error names the filter value that
+	 * failed and lists the available PIE contexts). With an empty Request the
+	 * first live candidate wins (historical behavior).
+	 */
+	int32 SelectPIEContextIndex(TArrayView<const FPIEContextCandidate> Candidates, const FPIEWorldRequest& Request, FString& OutError);
+
+	/**
+	 * Engine-facing entry point: enumerate GEngine's PIE world contexts,
+	 * apply the request parsed from Arguments, and return the selected world.
+	 * Returns nullptr with OutError set on any failure (no PIE session, bad
+	 * parameter, or no context matching the filters).
+	 */
+	UWorld* ResolvePIEWorld(const TSharedPtr<FJsonObject>& Arguments, FString& OutError);
+
+	/**
+	 * Add the shared 'pie_instance' and 'net_mode' property declarations to a
+	 * tool schema's "properties" object.
+	 */
+	void AddSchemaParams(const TSharedPtr<FJsonObject>& Properties);
+
+	/**
+	 * Test-only seam: while set to a non-null world, ResolvePIEWorld returns
+	 * that world unconditionally (before any parsing or enumeration). Pass
+	 * nullptr to clear. Must be balanced by the test that sets it.
+	 */
+	void SetPIEWorldOverrideForTesting(UWorld* World);
+}

--- a/Source/Claireon/Private/ClaireonToolSearchIndex.cpp
+++ b/Source/Claireon/Private/ClaireonToolSearchIndex.cpp
@@ -277,7 +277,7 @@ namespace Cl628IdxInternal
 		for (const auto& PropPair : (*PropertiesObj)->Values)
 		{
 			// Parameter name
-			Parts.Add(PropPair.Key);
+			Parts.Add(FString(*PropPair.Key));
 
 			const TSharedPtr<FJsonObject>* PropSchema = nullptr;
 			if (!PropPair.Value.IsValid() || !PropPair.Value->TryGetObject(PropSchema) || !PropSchema)

--- a/Source/Claireon/Private/ClaireonWidgetHelpers.cpp
+++ b/Source/Claireon/Private/ClaireonWidgetHelpers.cpp
@@ -29,6 +29,8 @@
 #include "WidgetBlueprintExtension.h"
 #include "Types/MVVMBindingMode.h"
 #include "Kismet2/BlueprintEditorUtils.h"
+#include "Misc/EngineVersionComparison.h"
+#include "UObject/Package.h"
 
 // ============================================================================
 // SerializeWidgetTree
@@ -333,7 +335,80 @@ UWidget* ClaireonWidgetHelpers::CreateWidget(UWidgetTree* Tree, TSubclassOf<UWid
 		return nullptr;
 	}
 
-	return Tree->ConstructWidget<UWidget>(WidgetClass, WidgetName);
+	UWidget* Widget = Tree->ConstructWidget<UWidget>(WidgetClass, WidgetName);
+	if (Widget)
+	{
+		NotifyVariableAdded(Cast<UWidgetBlueprint>(Tree->GetOuter()), Widget->GetFName());
+	}
+	return Widget;
+}
+
+// ============================================================================
+// Widget variable GUID bookkeeping (UE 5.8+)
+// ============================================================================
+
+void ClaireonWidgetHelpers::NotifyVariableAdded(UWidgetBlueprint* WidgetBP, FName VariableName)
+{
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+	if (WidgetBP && !VariableName.IsNone() && !WidgetBP->WidgetVariableNameToGuidMap.Contains(VariableName))
+	{
+		WidgetBP->OnVariableAdded(VariableName);
+	}
+#endif
+}
+
+void ClaireonWidgetHelpers::NotifyVariableRemoved(UWidgetBlueprint* WidgetBP, FName VariableName)
+{
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+	if (WidgetBP && !VariableName.IsNone())
+	{
+		WidgetBP->OnVariableRemoved(VariableName);
+	}
+#endif
+}
+
+void ClaireonWidgetHelpers::NotifyVariableRenamed(UWidgetBlueprint* WidgetBP, FName OldName, FName NewName)
+{
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+	if (!WidgetBP || NewName.IsNone() || OldName == NewName)
+	{
+		return;
+	}
+	// OnVariableRenamed ensures on a missing old entry and an existing new entry;
+	// pre-check so assets created before this bookkeeping existed stay quiet.
+	if (WidgetBP->WidgetVariableNameToGuidMap.Contains(OldName) &&
+		!WidgetBP->WidgetVariableNameToGuidMap.Contains(NewName))
+	{
+		WidgetBP->OnVariableRenamed(OldName, NewName);
+	}
+	else
+	{
+		NotifyVariableAdded(WidgetBP, NewName);
+	}
+#endif
+}
+
+void ClaireonWidgetHelpers::TrashRemovedWidget(UWidgetBlueprint* WidgetBP, UWidget* Widget)
+{
+	if (!Widget)
+	{
+		return;
+	}
+	// Engine designer pattern (FWidgetBlueprintEditorUtils::DeleteWidgets): removed
+	// widgets stay outered to the widget tree, so until they are reparented to the
+	// transient package they still count as source widgets (5.8's GUID validation
+	// resurrects their map entries) and their names collide with future widgets.
+	TArray<UWidget*> Subtree;
+	Subtree.Add(Widget);
+	UWidgetTree::GetChildWidgets(Widget, Subtree);
+	for (UWidget* Removed : Subtree)
+	{
+		const FName RemovedName = Removed->GetFName();
+		Removed->SetFlags(RF_Transactional);
+		Removed->Modify();
+		Removed->Rename(nullptr, GetTransientPackage());
+		NotifyVariableRemoved(WidgetBP, RemovedName);
+	}
 }
 
 // ============================================================================
@@ -367,7 +442,7 @@ UPanelSlot* ClaireonWidgetHelpers::AddChildToPanel(UPanelWidget* Parent, UWidget
 			}
 			FString PropStrVal = Pair.Value.IsValid() ? Pair.Value->AsString() : TEXT("");
 			FString Error;
-			WriteSlotProperty(Slot, Pair.Key, PropStrVal, Error);
+			WriteSlotProperty(Slot, FString(*Pair.Key), PropStrVal, Error);
 		}
 	}
 

--- a/Source/Claireon/Private/ClaireonXmlFormatter.cpp
+++ b/Source/Claireon/Private/ClaireonXmlFormatter.cpp
@@ -308,7 +308,7 @@ FString FClaireonXmlFormatter::GenerateTypeSignature(const FString& ToolName, co
 	TArray<FString> ParamStrings;
 	for (const auto& Pair : (*PropertiesPtr)->Values)
 	{
-		const FString& ParamName = Pair.Key;
+		const FString ParamName(*Pair.Key);
 		const TSharedPtr<FJsonObject>* PropObj = nullptr;
 
 		FString TypeStr = TEXT("any");

--- a/Source/Claireon/Private/Tests/ClaireonGasToolsContractTests.cpp
+++ b/Source/Claireon/Private/Tests/ClaireonGasToolsContractTests.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+// Contract tests for the runtime GAS tools (gas_runtime_inspect / gas_apply_effect /
+// gas_remove_effect / gas_grant_ability / gas_activate_ability / gas_set_tags /
+// gas_set_attribute). Runtime GAS behavior needs a live PIE session and cannot
+// be exercised headless, so these lock the pure, environment-independent
+// contract: exact tool names, ReadOnly session mode, the shared
+// actorId/net_mode/pie_instance schema surface, and the missing-actorId error
+// path. Manual PIE smoke coverage is documented in CLAIREON-GAS-TOOLS-SPEC.md
+// section 4 (mirrors how pie_test_ability is covered).
+
+#if WITH_UNTESTED
+
+#include "Untest.h"
+
+#include "Tools/IClaireonTool.h"
+#include "Tools/ClaireonTool_GasInspect.h"
+#include "Tools/ClaireonTool_GasApplyEffect.h"
+#include "Tools/ClaireonTool_GasRemoveEffect.h"
+#include "Tools/ClaireonTool_GasGrantAbility.h"
+#include "Tools/ClaireonTool_GasActivateAbility.h"
+#include "Tools/ClaireonTool_GasSetTags.h"
+#include "Tools/ClaireonTool_GasSetAttribute.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+
+namespace ClaireonGasToolsContractHelpers
+{
+	struct FNamedTool
+	{
+		TSharedPtr<IClaireonTool> Tool;
+		FString ExpectedName;
+	};
+
+	// One instance of every gas_* tool paired with its expected wire name.
+	static TArray<FNamedTool> MakeGasTools()
+	{
+		TArray<FNamedTool> Tools;
+		Tools.Add({ MakeShared<ClaireonTool_GasInspect>(),         TEXT("gas_runtime_inspect") });
+		Tools.Add({ MakeShared<ClaireonTool_GasApplyEffect>(),     TEXT("gas_apply_effect") });
+		Tools.Add({ MakeShared<ClaireonTool_GasRemoveEffect>(),    TEXT("gas_remove_effect") });
+		Tools.Add({ MakeShared<ClaireonTool_GasGrantAbility>(),    TEXT("gas_grant_ability") });
+		Tools.Add({ MakeShared<ClaireonTool_GasActivateAbility>(), TEXT("gas_activate_ability") });
+		Tools.Add({ MakeShared<ClaireonTool_GasSetTags>(),         TEXT("gas_set_tags") });
+		Tools.Add({ MakeShared<ClaireonTool_GasSetAttribute>(),    TEXT("gas_set_attribute") });
+		return Tools;
+	}
+
+	static bool SchemaHasProperty(const TSharedPtr<FJsonObject>& Schema, const TCHAR* PropertyName)
+	{
+		if (!Schema.IsValid()) { return false; }
+		const TSharedPtr<FJsonObject>* Properties = nullptr;
+		if (!Schema->TryGetObjectField(TEXT("properties"), Properties) || Properties == nullptr)
+		{
+			return false;
+		}
+		return (*Properties)->HasField(PropertyName);
+	}
+
+	static bool SchemaRequires(const TSharedPtr<FJsonObject>& Schema, const FString& Field)
+	{
+		if (!Schema.IsValid()) { return false; }
+		const TArray<TSharedPtr<FJsonValue>>* Required = nullptr;
+		if (!Schema->TryGetArrayField(TEXT("required"), Required) || Required == nullptr)
+		{
+			return false;
+		}
+		for (const TSharedPtr<FJsonValue>& Value : *Required)
+		{
+			if (Value.IsValid() && Value->AsString() == Field)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+using namespace ClaireonGasToolsContractHelpers;
+
+UNTEST_UNIT(Claireon, GasToolsContract, ToolNamesAreExact)
+{
+	for (const FNamedTool& Entry : MakeGasTools())
+	{
+		UNTEST_ASSERT_TRUE(Entry.Tool.IsValid());
+		UNTEST_EXPECT_STREQ(*Entry.Tool->GetName(), *Entry.ExpectedName);
+	}
+	co_return;
+}
+
+UNTEST_UNIT(Claireon, GasToolsContract, AllToolsAreReadOnlySession)
+{
+	// These mutate PIE runtime, not on-disk assets -- no asset-session handling.
+	for (const FNamedTool& Entry : MakeGasTools())
+	{
+		UNTEST_EXPECT_TRUE(Entry.Tool->GetSessionMode() == EClaireonToolSessionMode::ReadOnly);
+		UNTEST_EXPECT_FALSE(Entry.Tool->RequiresNoPIE());
+	}
+	co_return;
+}
+
+UNTEST_UNIT(Claireon, GasToolsContract, SchemasExposeActorIdAndPieParams)
+{
+	for (const FNamedTool& Entry : MakeGasTools())
+	{
+		const TSharedPtr<FJsonObject> Schema = Entry.Tool->GetInputSchema();
+		UNTEST_ASSERT_TRUE(Schema.IsValid());
+		// Shared surface from ClaireonGasToolCommon::AddCommonSchemaParams.
+		UNTEST_EXPECT_TRUE(SchemaHasProperty(Schema, TEXT("actorId")));
+		UNTEST_EXPECT_TRUE(SchemaHasProperty(Schema, TEXT("pie_instance")));
+		UNTEST_EXPECT_TRUE(SchemaHasProperty(Schema, TEXT("net_mode")));
+		// Every gas_* tool marks actorId required.
+		UNTEST_EXPECT_TRUE(SchemaRequires(Schema, TEXT("actorId")));
+	}
+	co_return;
+}
+
+UNTEST_UNIT(Claireon, GasToolsContract, MissingActorIdIsAnError)
+{
+	// Environment-independent: actorId is validated before the PIE guard, so an
+	// empty arg object errors on actorId regardless of whether PIE is running.
+	for (const FNamedTool& Entry : MakeGasTools())
+	{
+		const TSharedPtr<FJsonObject> Args = MakeShared<FJsonObject>();
+		const IClaireonTool::FToolResult Result = Entry.Tool->Execute(Args);
+		UNTEST_EXPECT_TRUE(Result.bIsError);
+		UNTEST_EXPECT_TRUE(Result.ErrorMessage.Contains(TEXT("actorId")));
+	}
+	co_return;
+}
+
+#endif // WITH_UNTESTED

--- a/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Batch.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Batch.cpp
@@ -327,7 +327,7 @@ FToolResult ClaireonAnimGraphTool_ApplyDelta::Execute(const TSharedPtr<FJsonObje
 					if (Pair.Value.IsValid() && Pair.Value->TryGetString(Value))
 					{
 						FString PropError;
-						if (!ClaireonPropertyUtils::WritePropertyByPath(NewNode, Pair.Key, Value, PropError))
+						if (!ClaireonPropertyUtils::WritePropertyByPath(NewNode, FString(*Pair.Key), Value, PropError))
 						{
 							Warnings.Add(FString::Printf(TEXT("Node '%s': property '%s': %s"), *LocalId, *Pair.Key, *PropError));
 						}

--- a/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Lifecycle.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Lifecycle.cpp
@@ -146,6 +146,10 @@ FToolResult ClaireonAnimGraphTool_Create::Execute(const TSharedPtr<FJsonObject>&
 		return MakeErrorResult(FString::Printf(TEXT("Failed to create package: %s"), *PackageName));
 	}
 
+	// Deleting the .uasset on disk above does not evict a same-named object still loaded
+	// in memory; UE 5.8 CreateBlueprint asserts the name is free, so clear it first.
+	ClaireonAssetUtils::EvictInMemoryObject(Package, AssetName);
+
 	// Create AnimBP (mirrors UAnimBlueprintFactory::FactoryCreateNew)
 	UAnimBlueprint* AnimBP = CastChecked<UAnimBlueprint>(
 		FKismetEditorUtilities::CreateBlueprint(
@@ -328,6 +332,8 @@ FToolResult ClaireonAnimGraphTool_CreateChild::Execute(const TSharedPtr<FJsonObj
 		return MakeErrorResult(FString::Printf(TEXT("Failed to create package: %s"), *PackageName));
 	}
 
+	ClaireonAssetUtils::EvictInMemoryObject(Package, AssetName);
+
 	// Create child AnimBP using parent's generated class
 	UAnimBlueprint* ChildBP = CastChecked<UAnimBlueprint>(
 		FKismetEditorUtilities::CreateBlueprint(
@@ -475,6 +481,7 @@ FToolResult ClaireonAnimGraphTool_Duplicate::Execute(const TSharedPtr<FJsonObjec
 		return MakeErrorResult(FString::Printf(TEXT("Failed to create destination package: %s"), *DestPackage));
 	}
 
+	ClaireonAssetUtils::EvictInMemoryObject(DestPkg, DestName);
 	UObject* DuplicatedObj = StaticDuplicateObject(SourceBP, DestPkg, FName(*DestName));
 	UAnimBlueprint* DuplicatedBP = Cast<UAnimBlueprint>(DuplicatedObj);
 	if (!DuplicatedBP)

--- a/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Node.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Node.cpp
@@ -191,7 +191,7 @@ FToolResult ClaireonAnimGraphTool_AddNode::Execute(const TSharedPtr<FJsonObject>
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(Value))
 			{
 				FString PropError;
-				if (!ClaireonPropertyUtils::WritePropertyByPath(NewNode, Pair.Key, Value, PropError))
+				if (!ClaireonPropertyUtils::WritePropertyByPath(NewNode, FString(*Pair.Key), Value, PropError))
 				{
 					Warnings.Add(FString::Printf(TEXT("Failed to set property '%s': %s"), *Pair.Key, *PropError));
 				}

--- a/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Variable.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAnimGraphTools_Variable.cpp
@@ -292,7 +292,7 @@ FToolResult ClaireonAnimGraphTool_SetVariableProperties::Execute(const TSharedPt
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(Value))
 			{
 				FBlueprintEditorUtils::SetBlueprintVariableMetaData(AnimBP, VarFName, LocalScope, FName(*Pair.Key), Value);
-				ChangedProps.Add(Pair.Key);
+				ChangedProps.Add(FString(*Pair.Key));
 			}
 		}
 	}

--- a/Source/Claireon/Private/Tools/ClaireonAnimTools_Notify.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAnimTools_Notify.cpp
@@ -121,7 +121,7 @@ IClaireonTool::FToolResult ClaireonAnimTool_AddNotify::Execute(const TSharedPtr<
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(PropValue))
 			{
 				FString PropError;
-				ClaireonAnimHelpers::SetNotifyProperty(Anim, NewIndex, Pair.Key, PropValue, PropError);
+				ClaireonAnimHelpers::SetNotifyProperty(Anim, NewIndex, FString(*Pair.Key), PropValue, PropError);
 				if (!PropError.IsEmpty())
 				{
 					UE_LOG(LogClaireon, Warning, TEXT("AddNotify: Failed to set property '%s': %s"), *Pair.Key, *PropError);

--- a/Source/Claireon/Private/Tools/ClaireonAssetUtils.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAssetUtils.cpp
@@ -321,6 +321,21 @@ UClass* ResolveClassName(const FString& ClassName)
 	return nullptr;
 }
 
+void EvictInMemoryObject(UPackage* Package, const FString& AssetName)
+{
+	if (!Package || AssetName.IsEmpty())
+	{
+		return;
+	}
+	if (UObject* Existing = StaticFindObject(UObject::StaticClass(), Package, *AssetName))
+	{
+		Existing->ClearFlags(RF_Public | RF_Standalone);
+		Existing->Rename(nullptr, GetTransientPackage(),
+			REN_DontCreateRedirectors | REN_NonTransactional | REN_DoNotDirty);
+		Existing->MarkAsGarbage();
+	}
+}
+
 bool AssertInnerNameMatchesPackage(const UObject* Asset, FString& OutError)
 {
 	OutError.Reset();

--- a/Source/Claireon/Private/Tools/ClaireonAudioApplyHelpers.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonAudioApplyHelpers.cpp
@@ -117,11 +117,11 @@ namespace ClaireonAudioApplyHelpers
 			if (AActor* AsActor = Cast<AActor>(Target))
 			{
 				ClaireonPropertyResolver::FResolvedProperty Resolved;
-				bOk = ClaireonPropertyResolver::WritePropertyOnActor(AsActor, Pair.Key, ValueStr, Resolved, Err);
+				bOk = ClaireonPropertyResolver::WritePropertyOnActor(AsActor, FString(*Pair.Key), ValueStr, Resolved, Err);
 			}
 			else
 			{
-				bOk = ClaireonPropertyUtils::WritePropertyByPath(Target, Pair.Key, ValueStr, Err);
+				bOk = ClaireonPropertyUtils::WritePropertyByPath(Target, FString(*Pair.Key), ValueStr, Err);
 			}
 			if (!bOk)
 			{

--- a/Source/Claireon/Private/Tools/ClaireonBlueprintGraphTool_AddNode.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonBlueprintGraphTool_AddNode.cpp
@@ -1067,6 +1067,12 @@ FToolResult ClaireonBlueprintGraphTool_AddNode::AddNode_Impl(
 
 	FToolResult AddNodeResult = BuildStateResponse(SessionId, Data);
 	AddNodeResult.Warnings.Append(ResolutionWarnings);
+	// Surface the new node's GUID directly so callers can chain follow-up ops (connect_pins,
+	// set_node_property, ...) without regexing it out of the cursor/summary block.
+	if (AddNodeResult.Data.IsValid())
+	{
+		AddNodeResult.Data->SetStringField(TEXT("created_node_guid"), NewNode->NodeGuid.ToString());
+	}
 	return AddNodeResult;
 }
 

--- a/Source/Claireon/Private/Tools/ClaireonBlueprintGraphTool_Compile.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonBlueprintGraphTool_Compile.cpp
@@ -10,6 +10,7 @@
 #include "Tools/ClaireonBlueprintGraphEditToolBase_Internal.h"
 #include "ClaireonLog.h"
 #include "ClaireonSafeExec.h"
+#include "Misc/EngineVersionComparison.h"
 #include "Engine/Blueprint.h"
 #include "EdGraph/EdGraph.h"
 #include "EdGraph/EdGraphNode.h"
@@ -145,14 +146,20 @@ FToolResult ClaireonBlueprintGraphTool_Compile::Execute(const TSharedPtr<FJsonOb
 	FCompilerResultsLog CompilerLog;
 	CompilerLog.SetSourcePath(Blueprint->GetPathName());
 	CompilerLog.BeginEvent(TEXT("Compile"));
-	// SkipSave: compile is documented as in-memory only (bp_save persists), and
-	// matches UBlueprintEditorLibrary::CompileBlueprint. SkipGarbageCollection:
-	// the synchronous CollectGarbage at the end of a compile livelocks on UE 5.8
-	// when invoked from inside the MCP request handler (the editor saturates all
-	// cores and the call never returns); the editor GCs on its own cadence soon
-	// after instead.
+	// SkipSave on every engine: without it, a user with Save-on-Compile enabled gets
+	// disk writes from a tool documented as in-memory only (bp_save persists); this
+	// also matches UBlueprintEditorLibrary::CompileBlueprint. SkipGarbageCollection
+	// on 5.8 only: there the synchronous CollectGarbage at the end of a compile
+	// livelocks when invoked from inside the MCP request handler (the editor
+	// saturates all cores and the call never returns); the editor GCs on its own
+	// cadence soon after. Earlier engines run the same GC without issue, so they
+	// keep it.
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
+	FKismetEditorUtilities::CompileBlueprint(Blueprint, EBlueprintCompileOptions::SkipSave, &CompilerLog);
+#else
 	FKismetEditorUtilities::CompileBlueprint(Blueprint,
 		EBlueprintCompileOptions::SkipSave | EBlueprintCompileOptions::SkipGarbageCollection, &CompilerLog);
+#endif
 	CompilerLog.EndEvent();
 
 	// Check compilation status

--- a/Source/Claireon/Private/Tools/ClaireonBlueprintGraphTool_Compile.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonBlueprintGraphTool_Compile.cpp
@@ -145,7 +145,14 @@ FToolResult ClaireonBlueprintGraphTool_Compile::Execute(const TSharedPtr<FJsonOb
 	FCompilerResultsLog CompilerLog;
 	CompilerLog.SetSourcePath(Blueprint->GetPathName());
 	CompilerLog.BeginEvent(TEXT("Compile"));
-	FKismetEditorUtilities::CompileBlueprint(Blueprint, EBlueprintCompileOptions::None, &CompilerLog);
+	// SkipSave: compile is documented as in-memory only (bp_save persists), and
+	// matches UBlueprintEditorLibrary::CompileBlueprint. SkipGarbageCollection:
+	// the synchronous CollectGarbage at the end of a compile livelocks on UE 5.8
+	// when invoked from inside the MCP request handler (the editor saturates all
+	// cores and the call never returns); the editor GCs on its own cadence soon
+	// after instead.
+	FKismetEditorUtilities::CompileBlueprint(Blueprint,
+		EBlueprintCompileOptions::SkipSave | EBlueprintCompileOptions::SkipGarbageCollection, &CompilerLog);
 	CompilerLog.EndEvent();
 
 	// Check compilation status

--- a/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_AddNode.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_AddNode.cpp
@@ -32,7 +32,7 @@ TSharedPtr<FJsonObject> FClaireonCameraAssetTool_AddNode::GetInputSchema() const
 	S.AddString(TEXT("asset_path"), TEXT("/Game/ path of the camera asset"), true);
 	S.AddInteger(TEXT("rig_index"), TEXT("Index of the rig to mutate"), true);
 	S.AddString(TEXT("parent_node_id"), TEXT("Node-id path to the parent node; empty to set the rig root"));
-	S.AddString(TEXT("node_class"), TEXT("UCameraNode subclass name (e.g. 'BVLookAtCameraNode')"), true);
+	S.AddString(TEXT("node_class"), TEXT("UCameraNode subclass name (e.g. 'OffsetCameraNode')"), true);
 	S.AddString(TEXT("after_child_node_id"), TEXT("Sibling node-id to insert after; empty/absent appends"));
 	return S.Build();
 }

--- a/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_AddRig.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_AddRig.cpp
@@ -118,15 +118,23 @@ IClaireonTool::FToolResult FClaireonCameraAssetTool_AddRig::Execute(const TShare
 	}
 	Asset->PostEditChange();
 #else
-	// 5.7: AddCameraRig() is gone; rigs live on the camera director. Attach to a
-	// USingleCameraDirector (the only single-rig slot).
+	// 5.7+: AddCameraRig() is gone; rigs live on the camera director. add_rig targets a
+	// USingleCameraDirector (the single-rig slot). A freshly created asset has no director
+	// yet (5.8 no longer installs a default one), so create + install one on demand.
 	USingleCameraDirector* Single = Cast<USingleCameraDirector>(Asset->GetCameraDirector());
 	if (!Single)
 	{
-		Transaction.Cancel();
-		return MakeErrorResult(TEXT(
-			"asset's camera director does not support add_rig on UE 5.7 "
-			"(expected a USingleCameraDirector)"));
+		if (UCameraDirector* Existing = Asset->GetCameraDirector())
+		{
+			// A different (e.g. multi-rig) director is already present -- don't clobber it.
+			Transaction.Cancel();
+			return MakeErrorResult(FString::Printf(TEXT(
+				"asset's camera director is a %s, not a USingleCameraDirector; "
+				"add_rig only supports single-rig directors"),
+				*Existing->GetClass()->GetName()));
+		}
+		Single = NewObject<USingleCameraDirector>(Asset, NAME_None, RF_Transactional | RF_Public);
+		Asset->SetCameraDirector(Single);
 	}
 	// Refuse rather than silently overwrite/orphan an existing rig (diverges from <=5.6 append).
 	if (Single->CameraRig)
@@ -134,7 +142,7 @@ IClaireonTool::FToolResult FClaireonCameraAssetTool_AddRig::Execute(const TShare
 		Transaction.Cancel();
 		return MakeErrorResult(TEXT(
 			"asset's USingleCameraDirector already references a rig; add_rig would "
-			"overwrite it on UE 5.7 (single-camera directors hold exactly one rig)"));
+			"overwrite it on UE 5.7+ (single-camera directors hold exactly one rig)"));
 	}
 	Single->Modify();
 	Single->CameraRig = NewRig;

--- a/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_Compile.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_Compile.cpp
@@ -19,6 +19,9 @@
 #else
 #include "Build/CameraBuildLog.h"
 #endif
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+#include "Build/CameraBuildContext.h"
+#endif
 
 FString FClaireonCameraAssetTool_Compile::GetOperation() const { return TEXT("compile"); }
 
@@ -59,7 +62,12 @@ IClaireonTool::FToolResult FClaireonCameraAssetTool_Compile::Execute(const TShar
 	}
 
 	UE::Cameras::FCameraBuildLog Log;
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	Asset->BuildCamera(Log);
+#else
+	UE::Cameras::FCameraBuildContext BuildContext(Log);
+	Asset->BuildCamera(BuildContext);
+#endif
 
 	bool bHasErrors = false;
 	for (const UE::Cameras::FCameraBuildLogMessage& M : Log.GetMessages())

--- a/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_GetNodeProperty.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_GetNodeProperty.cpp
@@ -28,7 +28,7 @@ TSharedPtr<FJsonObject> FClaireonCameraAssetTool_GetNodeProperty::GetInputSchema
 	S.AddString(TEXT("asset_path"), TEXT("/Game/ path of the camera asset"), true);
 	S.AddInteger(TEXT("rig_index"), TEXT("Index of the rig containing the node"), true);
 	S.AddString(TEXT("node_id"), TEXT("Node-id path of the target node"), true);
-	S.AddString(TEXT("property_path"), TEXT("Dotted property path (e.g. 'InterpSpeed' or 'BlendSettings.Easing')"), true);
+	S.AddString(TEXT("property_path"), TEXT("Dotted property path (e.g. 'FieldOfView.Value' or 'BlendSettings.Easing')"), true);
 	return S.Build();
 }
 

--- a/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_NodeMutation.spec.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_NodeMutation.spec.cpp
@@ -381,7 +381,7 @@ bool FCameraAssetNodeMutation_AddNode_AsRoot::RunTest(const FString& /*Parameter
 
 // =====================================================================================
 // Test: AddNode_AsChildOfArray
-// Array root + AddNode parent_node_id="Root" class UBVLookAtCameraNode -> ListNodes
+// Array root + AddNode parent_node_id="Root" class UFieldOfViewCameraNode -> ListNodes
 // returns 2 entries; child is at "Root.Children[0]".
 // =====================================================================================
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCameraAssetNodeMutation_AddNode_AsChildOfArray,
@@ -408,7 +408,7 @@ bool FCameraAssetNodeMutation_AddNode_AsChildOfArray::RunTest(const FString& /*P
 			return false;
 		}
 	}
-	const auto ChildResult = CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("BVLookAtCameraNode"));
+	const auto ChildResult = CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("FieldOfViewCameraNode"));
 	if (ChildResult.bIsError)
 	{
 		AddError(FString::Printf(TEXT("AddNode(child) failed: %s"), *ChildResult.ErrorMessage));
@@ -444,7 +444,7 @@ bool FCameraAssetNodeMutation_AddNode_AsChildOfArray::RunTest(const FString& /*P
 
 // =====================================================================================
 // Test: AddNode_NonArrayParentRejects
-// Add UBVPostProcessCameraNode as root -> try AddNode under it -> error containing
+// Add UPostProcessCameraNode as root -> try AddNode under it -> error containing
 // "no array child slot".
 // =====================================================================================
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCameraAssetNodeMutation_AddNode_NonArrayParentRejects,
@@ -463,7 +463,7 @@ bool FCameraAssetNodeMutation_AddNode_NonArrayParentRejects::RunTest(const FStri
 	}
 
 	{
-		const auto R = CANodeMutationSpec_AddNode(Path, FString(), TEXT("BVPostProcessCameraNode"));
+		const auto R = CANodeMutationSpec_AddNode(Path, FString(), TEXT("PostProcessCameraNode"));
 		if (R.bIsError)
 		{
 			AddError(FString::Printf(TEXT("AddNode(root) failed: %s"), *R.ErrorMessage));
@@ -472,7 +472,7 @@ bool FCameraAssetNodeMutation_AddNode_NonArrayParentRejects::RunTest(const FStri
 		}
 	}
 
-	const auto Result = CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("BVLookAtCameraNode"));
+	const auto Result = CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("FieldOfViewCameraNode"));
 	if (!Result.bIsError)
 	{
 		AddError(TEXT("AddNode under non-array parent did not error"));
@@ -512,7 +512,7 @@ bool FCameraAssetNodeMutation_RemoveNode_ChildOfArray::RunTest(const FString& /*
 		return false;
 	}
 
-	if (CANodeMutationSpec_AddNode(Path, FString(), TEXT("ArrayCameraNode")).bIsError || CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("BVLookAtCameraNode")).bIsError || CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("BVPostProcessCameraNode")).bIsError)
+	if (CANodeMutationSpec_AddNode(Path, FString(), TEXT("ArrayCameraNode")).bIsError || CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("FieldOfViewCameraNode")).bIsError || CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("PostProcessCameraNode")).bIsError)
 	{
 		AddError(TEXT("Setup AddNode call(s) failed"));
 		CANodeMutationSpec_DeleteIfExists(Path);
@@ -542,7 +542,7 @@ bool FCameraAssetNodeMutation_RemoveNode_ChildOfArray::RunTest(const FString& /*
 	}
 
 	// Find the child entry; it should now be at Root.Children[0] and class
-	// BVPostProcessCameraNode (the surviving sibling).
+	// PostProcessCameraNode (the surviving sibling).
 	bool bFoundChild = false;
 	for (const TSharedPtr<FJsonValue>& V : *Nodes)
 	{
@@ -553,10 +553,10 @@ bool FCameraAssetNodeMutation_RemoveNode_ChildOfArray::RunTest(const FString& /*
 		{
 			FString Cls;
 			Entry->TryGetStringField(TEXT("class"), Cls);
-			if (Cls != TEXT("BVPostProcessCameraNode"))
+			if (Cls != TEXT("PostProcessCameraNode"))
 			{
 				AddError(FString::Printf(
-					TEXT("Surviving child class='%s', expected 'BVPostProcessCameraNode'"),
+					TEXT("Surviving child class='%s', expected 'PostProcessCameraNode'"),
 					*Cls));
 				CANodeMutationSpec_DeleteIfExists(Path);
 				return false;
@@ -597,9 +597,9 @@ bool FCameraAssetNodeMutation_MoveNode_ReorderWithinParent::RunTest(const FStrin
 	}
 
 	// Add root + three distinct-class children so we can identify them post-move.
-	if (CANodeMutationSpec_AddNode(Path, FString(), TEXT("ArrayCameraNode")).bIsError || CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("BVLookAtCameraNode")).bIsError || // orig0
-		CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("BVPostProcessCameraNode")).bIsError ||																				// orig1
-		CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("BVPlayCameraAnimationCameraNode")).bIsError)																		// orig2
+	if (CANodeMutationSpec_AddNode(Path, FString(), TEXT("ArrayCameraNode")).bIsError || CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("FieldOfViewCameraNode")).bIsError || // orig0
+		CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("PostProcessCameraNode")).bIsError ||																				// orig1
+		CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("BoomArmCameraNode")).bIsError)																		// orig2
 	{
 		AddError(TEXT("Setup AddNode call(s) failed"));
 		CANodeMutationSpec_DeleteIfExists(Path);
@@ -630,9 +630,9 @@ bool FCameraAssetNodeMutation_MoveNode_ReorderWithinParent::RunTest(const FStrin
 	}
 
 	// Expected final order:
-	//   Root.Children[0] = BVLookAtCameraNode             (orig0, untouched)
-	//   Root.Children[1] = BVPlayCameraAnimationCameraNode (orig2, moved)
-	//   Root.Children[2] = BVPostProcessCameraNode         (orig1, shifted)
+	//   Root.Children[0] = FieldOfViewCameraNode             (orig0, untouched)
+	//   Root.Children[1] = BoomArmCameraNode (orig2, moved)
+	//   Root.Children[2] = PostProcessCameraNode         (orig1, shifted)
 	auto FindClassAt = [&](const FString& Id) -> FString
 	{
 		for (const TSharedPtr<FJsonValue>& V : *Nodes)
@@ -654,10 +654,10 @@ bool FCameraAssetNodeMutation_MoveNode_ReorderWithinParent::RunTest(const FStrin
 	const FString At1 = FindClassAt(TEXT("Root.Children[1]"));
 	const FString At2 = FindClassAt(TEXT("Root.Children[2]"));
 
-	if (At0 != TEXT("BVLookAtCameraNode") || At1 != TEXT("BVPlayCameraAnimationCameraNode") || At2 != TEXT("BVPostProcessCameraNode"))
+	if (At0 != TEXT("FieldOfViewCameraNode") || At1 != TEXT("BoomArmCameraNode") || At2 != TEXT("PostProcessCameraNode"))
 	{
 		AddError(FString::Printf(
-			TEXT("Post-move order mismatch: [0]='%s' [1]='%s' [2]='%s' (expected LookAt, PlayCameraAnimation, PostProcess)"),
+			TEXT("Post-move order mismatch: [0]='%s' [1]='%s' [2]='%s' (expected FieldOfView, BoomArm, PostProcess)"),
 			*At0, *At1, *At2));
 		CANodeMutationSpec_DeleteIfExists(Path);
 		return false;
@@ -669,7 +669,7 @@ bool FCameraAssetNodeMutation_MoveNode_ReorderWithinParent::RunTest(const FStrin
 
 // =====================================================================================
 // Test: SetGetNodeProperty_RoundTrip
-// Array root + UBVLookAtCameraNode child -> SetNodeProperty(InterpSpeed=7.5) ->
+// Array root + UFieldOfViewCameraNode child -> SetNodeProperty(FieldOfView.Value=7.5) ->
 // GetNodeProperty returns "7.5". Save + unload + reload -> GetNodeProperty STILL
 // returns "7.5". Verifies the PostEditChange cascade dirties the package and the
 // value persists across serialization.
@@ -689,7 +689,7 @@ bool FCameraAssetNodeMutation_SetGetNodeProperty_RoundTrip::RunTest(const FStrin
 		return false;
 	}
 
-	if (CANodeMutationSpec_AddNode(Path, FString(), TEXT("ArrayCameraNode")).bIsError || CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("BVLookAtCameraNode")).bIsError)
+	if (CANodeMutationSpec_AddNode(Path, FString(), TEXT("ArrayCameraNode")).bIsError || CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("FieldOfViewCameraNode")).bIsError)
 	{
 		AddError(TEXT("Setup AddNode call(s) failed"));
 		CANodeMutationSpec_DeleteIfExists(Path);
@@ -697,7 +697,7 @@ bool FCameraAssetNodeMutation_SetGetNodeProperty_RoundTrip::RunTest(const FStrin
 	}
 
 	const FString ChildId = TEXT("Root.Children[0]");
-	const FString PropName = TEXT("InterpSpeed");
+	const FString PropName = TEXT("FieldOfView.Value");
 	const FString TargetValue = TEXT("7.5");
 
 	{
@@ -725,7 +725,8 @@ bool FCameraAssetNodeMutation_SetGetNodeProperty_RoundTrip::RunTest(const FStrin
 			CANodeMutationSpec_DeleteIfExists(Path);
 			return false;
 		}
-		if (GotValue != TargetValue)
+		// ExportText for floats may render "7.5", "7.500000", etc. Compare numerically.
+		if (!FMath::IsNearlyEqual(FCString::Atof(*GotValue), FCString::Atof(*TargetValue)))
 		{
 			AddError(FString::Printf(
 				TEXT("Pre-save value mismatch: got '%s', expected '%s'"),
@@ -771,7 +772,7 @@ bool FCameraAssetNodeMutation_SetGetNodeProperty_RoundTrip::RunTest(const FStrin
 			CANodeMutationSpec_DeleteIfExists(Path);
 			return false;
 		}
-		if (GotValue != TargetValue)
+		if (!FMath::IsNearlyEqual(FCString::Atof(*GotValue), FCString::Atof(*TargetValue)))
 		{
 			AddError(FString::Printf(
 				TEXT("Persistence failed: post-reload value '%s', expected '%s'"),
@@ -787,9 +788,9 @@ bool FCameraAssetNodeMutation_SetGetNodeProperty_RoundTrip::RunTest(const FStrin
 
 // =====================================================================================
 // Test: SetNodeProperty_BadPath
-// Array root + UBVLookAtCameraNode child -> SetNodeProperty(BogusProperty=1) ->
+// Array root + UFieldOfViewCameraNode child -> SetNodeProperty(BogusProperty=1) ->
 // expect bIsError=true. Then verify the node is unchanged by reading another
-// known property (InterpSpeed, default 5.0) and confirming the default value.
+// known property (FieldOfView.Value, default 90.0) and confirming the default value.
 // =====================================================================================
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCameraAssetNodeMutation_SetNodeProperty_BadPath,
 	"Claireon.CameraAsset.NodeMutation.SetNodeProperty_BadPath",
@@ -806,7 +807,7 @@ bool FCameraAssetNodeMutation_SetNodeProperty_BadPath::RunTest(const FString& /*
 		return false;
 	}
 
-	if (CANodeMutationSpec_AddNode(Path, FString(), TEXT("ArrayCameraNode")).bIsError || CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("BVLookAtCameraNode")).bIsError)
+	if (CANodeMutationSpec_AddNode(Path, FString(), TEXT("ArrayCameraNode")).bIsError || CANodeMutationSpec_AddNode(Path, TEXT("Root"), TEXT("FieldOfViewCameraNode")).bIsError)
 	{
 		AddError(TEXT("Setup AddNode call(s) failed"));
 		CANodeMutationSpec_DeleteIfExists(Path);
@@ -823,27 +824,27 @@ bool FCameraAssetNodeMutation_SetNodeProperty_BadPath::RunTest(const FString& /*
 		return false;
 	}
 
-	// Verify a real property is untouched (UBVLookAtCameraNode::InterpSpeed default = 5.0f).
-	const auto GetResult = CANodeMutationSpec_GetNodeProperty(Path, ChildId, TEXT("InterpSpeed"));
+	// Verify a real property is untouched (UFieldOfViewCameraNode::FieldOfView.Value default = 90.0f).
+	const auto GetResult = CANodeMutationSpec_GetNodeProperty(Path, ChildId, TEXT("FieldOfView.Value"));
 	if (GetResult.bIsError)
 	{
-		AddError(FString::Printf(TEXT("GetNodeProperty(InterpSpeed) failed: %s"), *GetResult.ErrorMessage));
+		AddError(FString::Printf(TEXT("GetNodeProperty(FieldOfView.Value) failed: %s"), *GetResult.ErrorMessage));
 		CANodeMutationSpec_DeleteIfExists(Path);
 		return false;
 	}
 	FString GotValue;
 	if (!GetResult.Data.IsValid() || !GetResult.Data->TryGetStringField(TEXT("value"), GotValue))
 	{
-		AddError(TEXT("GetNodeProperty(InterpSpeed) result missing 'value'"));
+		AddError(TEXT("GetNodeProperty(FieldOfView.Value) result missing 'value'"));
 		CANodeMutationSpec_DeleteIfExists(Path);
 		return false;
 	}
-	// ExportText for floats may render "5.0", "5.000000", etc. Convert + compare numerically.
+	// ExportText for floats may render "90.0", "90.000000", etc. Convert + compare numerically.
 	const float Numeric = FCString::Atof(*GotValue);
-	if (!FMath::IsNearlyEqual(Numeric, 5.0f))
+	if (!FMath::IsNearlyEqual(Numeric, 90.0f))
 	{
 		AddError(FString::Printf(
-			TEXT("InterpSpeed unexpectedly changed after bad-path write: '%s' (-> %f, expected 5.0)"),
+			TEXT("FieldOfView.Value unexpectedly changed after bad-path write: '%s' (-> %f, expected 90.0)"),
 			*GotValue, Numeric));
 		CANodeMutationSpec_DeleteIfExists(Path);
 		return false;

--- a/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_Save.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_Save.cpp
@@ -21,6 +21,9 @@
 #else
 #include "Build/CameraBuildLog.h"
 #endif
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+#include "Build/CameraBuildContext.h"
+#endif
 
 FString FClaireonCameraAssetTool_Save::GetOperation() const { return TEXT("save"); }
 
@@ -65,7 +68,12 @@ IClaireonTool::FToolResult FClaireonCameraAssetTool_Save::Execute(const TSharedP
 	// triggers the discard-overload PreSave path. The dual call is intentional —
 	// PreSave's rebuild against the same in-memory state is largely idempotent.
 	UE::Cameras::FCameraBuildLog Log;
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	Asset->BuildCamera(Log);
+#else
+	UE::Cameras::FCameraBuildContext BuildContext(Log);
+	Asset->BuildCamera(BuildContext);
+#endif
 
 	int32 ErrorCount = 0;
 	for (const UE::Cameras::FCameraBuildLogMessage& M : Log.GetMessages())

--- a/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_SetNodeProperty.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_SetNodeProperty.cpp
@@ -31,7 +31,7 @@ TSharedPtr<FJsonObject> FClaireonCameraAssetTool_SetNodeProperty::GetInputSchema
 	S.AddString(TEXT("asset_path"), TEXT("/Game/ path of the camera asset"), true);
 	S.AddInteger(TEXT("rig_index"), TEXT("Index of the rig containing the node"), true);
 	S.AddString(TEXT("node_id"), TEXT("Node-id path of the target node"), true);
-	S.AddString(TEXT("property_path"), TEXT("Dotted property path (e.g. 'InterpSpeed' or 'BlendSettings.Easing')"), true);
+	S.AddString(TEXT("property_path"), TEXT("Dotted property path (e.g. 'FieldOfView.Value' or 'BlendSettings.Easing')"), true);
 	S.AddString(TEXT("value"), TEXT("New value as exported text (parsed via ImportText_Direct)"), true);
 	return S.Build();
 }

--- a/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_SmokeTest.spec.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonCameraAssetTool_SmokeTest.spec.cpp
@@ -170,7 +170,7 @@ bool FCameraAssetSmokeTest_SyntheticFixtureRoundTrip::RunTest(const FString& /*P
 {
 	const FString Path = TEXT("/Game/Tests/CA_Synth_Fixture");
 	const FString ChildId = TEXT("Root.Children[0]");
-	const FString PropName = TEXT("InterpSpeed");
+	const FString PropName = TEXT("FieldOfView.Value");
 	const FString TargetValue = TEXT("7.5");
 	CASmokeSpec_DeleteIfExists(Path);
 
@@ -203,9 +203,9 @@ bool FCameraAssetSmokeTest_SyntheticFixtureRoundTrip::RunTest(const FString& /*P
 			return false;
 		}
 	}
-	// 4. AddNode child = UBVLookAtCameraNode.
+	// 4. AddNode child = UFieldOfViewCameraNode.
 	{
-		const auto R = CASmokeSpec_AddNode(Path, 0, TEXT("Root"), TEXT("BVLookAtCameraNode"));
+		const auto R = CASmokeSpec_AddNode(Path, 0, TEXT("Root"), TEXT("FieldOfViewCameraNode"));
 		if (R.bIsError)
 		{
 			AddError(FString::Printf(TEXT("AddNode(child) failed: %s"), *R.ErrorMessage));
@@ -213,7 +213,7 @@ bool FCameraAssetSmokeTest_SyntheticFixtureRoundTrip::RunTest(const FString& /*P
 			return false;
 		}
 	}
-	// 5. SetNodeProperty InterpSpeed = "7.5".
+	// 5. SetNodeProperty FieldOfView.Value = "7.5".
 	{
 		const auto R = CASmokeSpec_SetNodeProperty(Path, 0, ChildId, PropName, TargetValue);
 		if (R.bIsError)
@@ -311,9 +311,9 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCameraAssetSmokeTest_DuplicatePrototypeAndAddN
 
 bool FCameraAssetSmokeTest_DuplicatePrototypeAndAddNode::RunTest(const FString& /*Parameters*/)
 {
-	const FString SourcePath = TEXT("/Game/BP/Camera/Fellowdivers/CA_FD_Player_Prototype_Ranged");
+	const FString SourcePath = TEXT("/Game/Tests/CA_Smoke_SourcePrototype");
 	const FString DupPath = TEXT("/Game/Tests/CA_Smoke_Prototype");
-	const FString PropName = TEXT("InterpSpeed");
+	const FString PropName = TEXT("FieldOfView.Value");
 	const FString TargetValue = TEXT("7.5");
 
 	// 1. Verify prototype exists; if not, soft-pass with warning.
@@ -404,10 +404,10 @@ bool FCameraAssetSmokeTest_DuplicatePrototypeAndAddNode::RunTest(const FString& 
 		return true;
 	}
 
-	// 5. AddNode UBVLookAtCameraNode under the array container.
+	// 5. AddNode UFieldOfViewCameraNode under the array container.
 	FString NewChildId;
 	{
-		const auto R = CASmokeSpec_AddNode(DupPath, RigIndex, ArrayParentId, TEXT("BVLookAtCameraNode"));
+		const auto R = CASmokeSpec_AddNode(DupPath, RigIndex, ArrayParentId, TEXT("FieldOfViewCameraNode"));
 		if (R.bIsError)
 		{
 			AddError(FString::Printf(TEXT("AddNode failed: %s"), *R.ErrorMessage));
@@ -422,7 +422,7 @@ bool FCameraAssetSmokeTest_DuplicatePrototypeAndAddNode::RunTest(const FString& 
 		}
 	}
 
-	// 6. SetNodeProperty InterpSpeed = "7.5".
+	// 6. SetNodeProperty FieldOfView.Value = "7.5".
 	{
 		const auto R = CASmokeSpec_SetNodeProperty(DupPath, RigIndex, NewChildId, PropName, TargetValue);
 		if (R.bIsError)
@@ -458,7 +458,7 @@ bool FCameraAssetSmokeTest_DuplicatePrototypeAndAddNode::RunTest(const FString& 
 		return false;
 	}
 
-	// 9. Reload + verify the new node persisted with InterpSpeed ~7.5.
+	// 9. Reload + verify the new node persisted with FieldOfView.Value ~7.5.
 	{
 		const auto R = CASmokeSpec_GetNodeProperty(DupPath, RigIndex, NewChildId, PropName);
 		if (R.bIsError)

--- a/Source/Claireon/Private/Tools/ClaireonChooserTool_RemoveRow.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonChooserTool_RemoveRow.cpp
@@ -9,6 +9,7 @@
 #include "ScopedTransaction.h"
 #include "Dom/JsonObject.h"
 #include "StructUtils/InstancedStruct.h"
+#include "Misc/EngineVersionComparison.h"
 
 FString ClaireonTool_ChooserRemoveRow::GetCategory() const { return TEXT("chooser"); }
 FString ClaireonTool_ChooserRemoveRow::GetOperation() const { return TEXT("remove_row"); }
@@ -68,8 +69,14 @@ IClaireonTool::FToolResult ClaireonTool_ChooserRemoveRow::Execute(const TSharedP
 	}
 
 	// Remove from each column's RowValues
+	// 5.8 changed FChooserColumnBase::DeleteRows to take TArrayView<int>.
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	TArray<uint32> RowIndices;
 	RowIndices.Add(static_cast<uint32>(RowIndex));
+#else
+	TArray<int32> RowIndices;
+	RowIndices.Add(RowIndex);
+#endif
 	for (FInstancedStruct& ColStruct : Chooser->ColumnsStructs)
 	{
 		if (ColStruct.IsValid())

--- a/Source/Claireon/Private/Tools/ClaireonDataTableHelpers.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonDataTableHelpers.cpp
@@ -235,7 +235,7 @@ bool SetPropertyValues(UDataTable* DataTable, FName RowName, const TSharedPtr<FJ
 
 	for (const auto& Pair : Values->Values)
 	{
-		const FString& Key = Pair.Key;
+		const FString Key(*Pair.Key);
 		const TSharedPtr<FJsonValue>& JsonValue = Pair.Value;
 
 		FProperty* Property = RowStruct->FindPropertyByName(FName(*Key));

--- a/Source/Claireon/Private/Tools/ClaireonDeveloperSettingsTool_Get.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonDeveloperSettingsTool_Get.cpp
@@ -4,6 +4,7 @@
 #include "Tools/ClaireonDeveloperSettingsTool_Get.h"
 #include "Tools/ClaireonAnimEditToolBase.h" // FToolSchemaBuilder
 #include "Tools/ClaireonPropertyUtils.h"
+#include "Tools/ClaireonAssetUtils.h"
 
 #include "Dom/JsonObject.h"
 #include "Engine/DeveloperSettings.h"
@@ -114,6 +115,16 @@ IClaireonTool::FToolResult FClaireonDeveloperSettingsTool_Get::Execute(const TSh
 	UClass* ResolvedClass = DevSettingsGet_ResolveClass(ClassPath);
 	if (!ResolvedClass)
 	{
+		// Disambiguate: if the identifier names a real, loaded class that simply isn't a
+		// UDeveloperSettings subclass, say so explicitly rather than "no match found".
+		UClass* AnyClass = ClassPath.StartsWith(TEXT("/Script/"))
+			? LoadObject<UClass>(nullptr, *ClassPath)
+			: ClaireonAssetUtils::ResolveClassName(ClassPath);
+		if (AnyClass && !AnyClass->IsChildOf(UDeveloperSettings::StaticClass()))
+		{
+			return MakeErrorResult(FString::Printf(
+				TEXT("Class '%s' is not a UDeveloperSettings subclass."), *AnyClass->GetName()));
+		}
 		return MakeErrorResult(FString::Printf(
 			TEXT("No loaded UDeveloperSettings subclass matched '%s'. "
 			     "Confirm the module containing the class is loaded and the name is spelled correctly."),

--- a/Source/Claireon/Private/Tools/ClaireonMaterialTool_AddExpression.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonMaterialTool_AddExpression.cpp
@@ -89,7 +89,7 @@ FToolResult ClaireonMaterialTool_AddExpression::Execute(const TSharedPtr<FJsonOb
 			if (!Pair.Value.IsValid()) continue;
 			const FString TextValue = Pair.Value->AsString();
 			FString PropErr;
-			ClaireonMaterialHelpers::SetExpressionProperty(Material, Expr, Pair.Key, TextValue, PropErr);
+			ClaireonMaterialHelpers::SetExpressionProperty(Material, Expr, FString(*Pair.Key), TextValue, PropErr);
 		}
 	}
 

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_BehaviorTree.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_BehaviorTree.cpp
@@ -412,7 +412,7 @@ bool FClaireonSpecApplicator_BehaviorTree::ApplyPass2_WireRelationships(const FS
 							if (Prop.Value->TryGetString(PropValue))
 							{
 								FString PropError;
-								if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, Prop.Key, PropValue, PropError))
+								if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, FString(*Prop.Key), PropValue, PropError))
 								{
 									AddWarning(FString::Printf(TEXT("Decorator '%s' property '%s': %s"), *DecId, *Prop.Key, *PropError));
 								}
@@ -480,7 +480,7 @@ bool FClaireonSpecApplicator_BehaviorTree::ApplyPass2_WireRelationships(const FS
 							if (Prop.Value->TryGetString(PropValue))
 							{
 								FString PropError;
-								if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, Prop.Key, PropValue, PropError))
+								if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, FString(*Prop.Key), PropValue, PropError))
 								{
 									AddWarning(FString::Printf(TEXT("Service '%s' property '%s': %s"), *SvcId, *Prop.Key, *PropError));
 								}
@@ -504,7 +504,7 @@ bool FClaireonSpecApplicator_BehaviorTree::ApplyPass2_WireRelationships(const FS
 					if (Prop.Value->TryGetString(PropValue))
 					{
 						FString PropError;
-						if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, Prop.Key, PropValue, PropError))
+						if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(BTNode, FString(*Prop.Key), PropValue, PropError))
 						{
 							AddWarning(FString::Printf(TEXT("Node '%s' property '%s': %s"), *SpecId, *Prop.Key, *PropError));
 						}

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_EQS.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_EQS.cpp
@@ -291,7 +291,7 @@ bool FClaireonSpecApplicator_EQS::ApplyPass2_WireRelationships(const FString& Se
 					if (Prop.Value->TryGetString(PropValue))
 					{
 						FString PropError;
-						if (!SpecApplicatorEQS_SetEQSProperty(Option->Generator, Prop.Key, PropValue, PropError))
+						if (!SpecApplicatorEQS_SetEQSProperty(Option->Generator, FString(*Prop.Key), PropValue, PropError))
 						{
 							AddWarning(FString::Printf(TEXT("Option '%s' generator property '%s': %s"), *SpecId, *Prop.Key, *PropError));
 						}
@@ -338,7 +338,7 @@ bool FClaireonSpecApplicator_EQS::ApplyPass2_WireRelationships(const FString& Se
 						if (Prop.Value->TryGetString(PropValue))
 						{
 							FString PropError;
-							if (!SpecApplicatorEQS_SetEQSProperty(NewTest, Prop.Key, PropValue, PropError))
+							if (!SpecApplicatorEQS_SetEQSProperty(NewTest, FString(*Prop.Key), PropValue, PropError))
 							{
 								AddWarning(FString::Printf(TEXT("Test '%s' property '%s': %s"), *TestId, *Prop.Key, *PropError));
 							}

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_Material.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_Material.cpp
@@ -364,7 +364,7 @@ bool FClaireonSpecApplicator_Material::ApplyPass1_CreateEntities(const FString& 
 					TextValue = Pair.Value->AsString(); // best-effort coercion
 				}
 				FString PropErr;
-				if (!ClaireonMaterialHelpers::SetExpressionProperty(Mat, Expr, Pair.Key, TextValue, PropErr))
+				if (!ClaireonMaterialHelpers::SetExpressionProperty(Mat, Expr, FString(*Pair.Key), TextValue, PropErr))
 				{
 					AddWarning(FString::Printf(TEXT("expression '%s': failed to set property '%s' = '%s' (%s)"),
 						*SpecId, *Pair.Key, *TextValue, *PropErr));

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_PCGGraph.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_PCGGraph.cpp
@@ -159,7 +159,7 @@ bool FClaireonSpecApplicator_PCGGraph::ApplyPass1_CreateEntities(const FString& 
 				if (Prop.Value->TryGetString(PropValue))
 				{
 					FString PropError;
-					if (!ClaireonPCGGraphHelpers::SetNodeProperty(NewNode, Prop.Key, PropValue, PropError))
+					if (!ClaireonPCGGraphHelpers::SetNodeProperty(NewNode, FString(*Prop.Key), PropValue, PropError))
 					{
 						AddWarning(FString::Printf(TEXT("Node '%s' property '%s': %s"), *SpecId, *Prop.Key, *PropError));
 					}

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_StateTree.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_StateTree.cpp
@@ -472,7 +472,7 @@ bool FClaireonSpecApplicator_StateTree::ApplyPass2_WireRelationships(const FStri
 						if (Prop.Value->TryGetString(PropValue))
 						{
 							FString PropError;
-							ClaireonStateTreeHelpers::SetNodeProperty(NewNode, Prop.Key, PropValue, false, PropError);
+							ClaireonStateTreeHelpers::SetNodeProperty(NewNode, FString(*Prop.Key), PropValue, false, PropError);
 						}
 					}
 				}
@@ -611,7 +611,7 @@ bool FClaireonSpecApplicator_StateTree::ApplyPass2_WireRelationships(const FStri
 						if (Prop.Value->TryGetString(PropValue))
 						{
 							FString PropError;
-							ClaireonStateTreeHelpers::SetNodeProperty(Node, Prop.Key, PropValue, false, PropError);
+							ClaireonStateTreeHelpers::SetNodeProperty(Node, FString(*Prop.Key), PropValue, false, PropError);
 						}
 					}
 					break;

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_WidgetBP.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_WidgetBP.cpp
@@ -454,7 +454,7 @@ bool FClaireonSpecApplicator_WidgetBP::ApplyPass2_WireRelationships(const FStrin
 					if (Prop.Value->TryGetString(PropValue))
 					{
 						FString PropError;
-						ClaireonWidgetHelpers::WriteSlotProperty(Slot, Prop.Key, PropValue, PropError);
+						ClaireonWidgetHelpers::WriteSlotProperty(Slot, FString(*Prop.Key), PropValue, PropError);
 					}
 				}
 			}
@@ -482,7 +482,7 @@ bool FClaireonSpecApplicator_WidgetBP::ApplyPass2_WireRelationships(const FStrin
 					if (Prop.Value->TryGetString(PropValue))
 					{
 						FString PropError;
-						if (!ClaireonWidgetHelpers::WriteWidgetProperty(Widget, Prop.Key, PropValue, PropError))
+						if (!ClaireonWidgetHelpers::WriteWidgetProperty(Widget, FString(*Prop.Key), PropValue, PropError))
 						{
 							AddWarning(FString::Printf(TEXT("Widget '%s' property '%s': %s"), *SpecId, *Prop.Key, *PropError));
 						}

--- a/Source/Claireon/Private/Tools/ClaireonSpecApplicator_WidgetBP.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonSpecApplicator_WidgetBP.cpp
@@ -3,6 +3,7 @@
 
 #include "Tools/ClaireonSpecApplicator_WidgetBP.h"
 #include "ClaireonWidgetHelpers.h"
+#include "Tools/ClaireonAssetUtils.h"
 #include "ClaireonNameResolver.h"
 #include "ClaireonPathResolver.h"
 #include "ClaireonSessionManager.h"
@@ -200,6 +201,10 @@ bool FClaireonSpecApplicator_WidgetBP::OpenOrCreateAsset(const FString& AssetPat
 			OutError = FString::Printf(TEXT("widgetbp_apply_spec auto-create: failed to create package '%s'"), *PackageName);
 			return false;
 		}
+
+		// Deleting the .uasset on disk above does not evict a same-named object still loaded in
+		// memory; UE 5.8 CreateBlueprint asserts the name is free, so clear it first.
+		ClaireonAssetUtils::EvictInMemoryObject(Package, AssetName);
 
 		UBlueprint* CreatedBP = FKismetEditorUtilities::CreateBlueprint(
 			ParentClass,

--- a/Source/Claireon/Private/Tools/ClaireonStateTreeEditInternal.h
+++ b/Source/Claireon/Private/Tools/ClaireonStateTreeEditInternal.h
@@ -13,6 +13,21 @@
 #include "StateTreeEditorData.h"
 #include "StateTreeEditorNode.h"
 #include "StateTreeTypes.h"
+#include "Misc/EngineVersionComparison.h"
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
+#include "StateTreePropertyBindings.h"
+#else
+#include "PropertyBindingPath.h"
+#endif
+
+// 5.8 removed FStateTreePropertyPath (and the FStateTreeEditorPropertyBindings
+// AddPropertyBinding/RemovePropertyBindings/AddFunctionPropertyBinding entry
+// points) in favor of FPropertyBindingPath and the FPropertyBindingBindingCollection API.
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
+using FClaireonPropertyPath = FStateTreePropertyPath;
+#else
+using FClaireonPropertyPath = FPropertyBindingPath;
+#endif
 
 namespace ClaireonStateTreeEditInternal
 {
@@ -226,9 +241,9 @@ namespace ClaireonStateTreeEditInternal
 			{
 				FString Error;
 				// Try on node struct first, then instance data
-				if (!ClaireonStateTreeHelpers::SetNodeProperty(Node, Pair.Key, Value, false, Error))
+				if (!ClaireonStateTreeHelpers::SetNodeProperty(Node, FString(*Pair.Key), Value, false, Error))
 				{
-					ClaireonStateTreeHelpers::SetNodeProperty(Node, Pair.Key, Value, true, Error);
+					ClaireonStateTreeHelpers::SetNodeProperty(Node, FString(*Pair.Key), Value, true, Error);
 				}
 			}
 		}

--- a/Source/Claireon/Private/Tools/ClaireonStateTreeHelpers.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonStateTreeHelpers.cpp
@@ -15,7 +15,7 @@
 #include "StateTreeNodeBase.h"
 #include "StateTreePropertyBindings.h"
 #include "StateTreeEditorPropertyBindings.h"
-#include "InstancedStruct.h"
+#include "StructUtils/InstancedStruct.h"
 #include "GameplayTagContainer.h"
 
 // ============================================================================

--- a/Source/Claireon/Private/Tools/ClaireonStateTreeTool_AddBinding.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonStateTreeTool_AddBinding.cpp
@@ -58,17 +58,21 @@ FToolResult ClaireonStateTreeTool_AddBinding::Execute(const TSharedPtr<FJsonObje
 		return MakeErrorResult(TEXT("Missing parameter: target_property"));
 
 #if WITH_EDITORONLY_DATA
-	FStateTreePropertyPath SourcePath(SourceNodeId);
+	FClaireonPropertyPath SourcePath(SourceNodeId);
 	SourcePath.FromString(SourceProperty);
 
-	FStateTreePropertyPath TargetPath(TargetNodeId);
+	FClaireonPropertyPath TargetPath(TargetNodeId);
 	TargetPath.FromString(TargetProperty);
 
 	FScopedTransaction Transaction(FText::FromString(TEXT("[Claireon] Add Property Binding")));
 	Data->StateTree->Modify();
 
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	FStateTreePropertyPathBinding Binding(SourcePath, TargetPath);
 	EditorData->EditorBindings.AddPropertyBinding(Binding);
+#else
+	EditorData->EditorBindings.AddBinding(SourcePath, TargetPath);
+#endif
 
 	Data->LastOperationStatus = FString::Printf(TEXT("add_binding -> Bound %s -> %s"), *SourceProperty, *TargetProperty);
 #else

--- a/Source/Claireon/Private/Tools/ClaireonStateTreeTool_AddPropertyFunction.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonStateTreeTool_AddPropertyFunction.cpp
@@ -86,13 +86,13 @@ FToolResult ClaireonStateTreeTool_AddPropertyFunction::Execute(const TSharedPtr<
 		return MakeErrorResult(FString::Printf(TEXT("'%s' is not a property function (must derive from FStateTreePropertyFunctionBase)"), *StructName));
 	}
 
-	FStateTreePropertyPath TargetPath(TargetNodeId);
+	FClaireonPropertyPath TargetPath(TargetNodeId);
 	TargetPath.FromString(TargetProperty);
 
 	TArray<FClaireonPropertyPathSegment> SourceSegments;
 	if (!SourceProperty.IsEmpty())
 	{
-		FStateTreePropertyPath TempPath;
+		FClaireonPropertyPath TempPath;
 		TempPath.FromString(SourceProperty);
 		SourceSegments = TempPath.GetSegments();
 	}
@@ -121,7 +121,11 @@ FToolResult ClaireonStateTreeTool_AddPropertyFunction::Execute(const TSharedPtr<
 	FScopedTransaction Transaction(FText::FromString(TEXT("[Claireon] Add Property Function Binding")));
 	Data->StateTree->Modify();
 
-	FStateTreePropertyPath ResultSourcePath = EditorData->EditorBindings.AddFunctionPropertyBinding(NodeStruct, SourceSegments, TargetPath);
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
+	FClaireonPropertyPath ResultSourcePath = EditorData->EditorBindings.AddFunctionPropertyBinding(NodeStruct, SourceSegments, TargetPath);
+#else
+	FClaireonPropertyPath ResultSourcePath = EditorData->EditorBindings.AddFunctionBinding(NodeStruct, SourceSegments, TargetPath);
+#endif
 
 	// Locate the just-added binding by target path, capture its embedded function-node
 	// GUID, and apply any optional initial properties in the same pass.
@@ -144,7 +148,7 @@ FToolResult ClaireonStateTreeTool_AddPropertyFunction::Execute(const TSharedPtr<
 						FString PropValue;
 						if (Pair.Value->TryGetString(PropValue))
 						{
-							ClaireonStateTreeHelpers::SetNodeProperty(EditorNode, Pair.Key, PropValue, true, Error);
+							ClaireonStateTreeHelpers::SetNodeProperty(EditorNode, FString(*Pair.Key), PropValue, true, Error);
 							if (!Error.IsEmpty())
 							{
 								UE_LOG(LogClaireon, Warning, TEXT("AddPropertyFunction: Failed to set property '%s': %s"), *Pair.Key, *Error);

--- a/Source/Claireon/Private/Tools/ClaireonStateTreeTool_RemoveBinding.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonStateTreeTool_RemoveBinding.cpp
@@ -52,12 +52,16 @@ FToolResult ClaireonStateTreeTool_RemoveBinding::Execute(const TSharedPtr<FJsonO
 		return MakeErrorResult(TEXT("Missing parameter: target_property"));
 
 #if WITH_EDITORONLY_DATA
-	FStateTreePropertyPath TargetPath(TargetNodeId);
+	FClaireonPropertyPath TargetPath(TargetNodeId);
 	TargetPath.FromString(TargetProperty);
 
 	FScopedTransaction Transaction(FText::FromString(TEXT("[Claireon] Remove Property Binding")));
 	Data->StateTree->Modify();
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	EditorData->EditorBindings.RemovePropertyBindings(TargetPath);
+#else
+	EditorData->EditorBindings.RemoveBindings(TargetPath);
+#endif
 
 	Data->LastOperationStatus = FString::Printf(TEXT("remove_binding -> Removed binding to %s"), *TargetProperty);
 #else

--- a/Source/Claireon/Private/Tools/ClaireonTool_BlueprintDiff.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_BlueprintDiff.cpp
@@ -232,7 +232,7 @@ void BuildSpecNodeEntry(const TSharedPtr<FJsonObject>& NodeObj, FSpecNodeEntry& 
 			FString PinValue;
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(PinValue))
 			{
-				Out.PinDefaults.Add(Pair.Key, PinValue);
+				Out.PinDefaults.Add(FString(*Pair.Key), PinValue);
 			}
 		}
 	}

--- a/Source/Claireon/Private/Tools/ClaireonTool_DataTableSetRowValues.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_DataTableSetRowValues.cpp
@@ -112,7 +112,7 @@ IClaireonTool::FToolResult ClaireonTool_DataTableSetRowValues::Execute(const TSh
 
 	for (const auto& Pair : Values->Values)
 	{
-		const FString& Key = Pair.Key;
+		const FString Key(*Pair.Key);
 
 		const FProperty* Prop = RowStruct ? RowStruct->FindPropertyByName(FName(*Key)) : nullptr;
 		if (!Prop)

--- a/Source/Claireon/Private/Tools/ClaireonTool_GasActivateAbility.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_GasActivateAbility.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#include "Tools/ClaireonTool_GasActivateAbility.h"
+
+#include "ClaireonGasToolCommon.h"
+
+#include "AbilitySystemComponent.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "GameFramework/Actor.h"
+#include "GameplayAbilitySpec.h"
+#include "GameplayTagContainer.h"
+#include "Abilities/GameplayAbility.h"
+
+FString ClaireonTool_GasActivateAbility::GetCategory() const { return TEXT("gas"); }
+FString ClaireonTool_GasActivateAbility::GetOperation() const { return TEXT("activate_ability"); }
+
+FString ClaireonTool_GasActivateAbility::GetDescription() const
+{
+	return TEXT("Activate an already-granted ability on a live PIE actor's ASC (grant it first with "
+		"gas_grant_ability). Address it by spec_handle_id (from gas_runtime_inspect / gas_grant_ability) or "
+		"ability_name (substring of a granted spec's class). Reports why activation was blocked when it "
+		"fails. Defaults to the server world. Requires PIE.");
+}
+
+EClaireonToolSessionMode ClaireonTool_GasActivateAbility::GetSessionMode() const
+{
+	return EClaireonToolSessionMode::ReadOnly;
+}
+
+TSharedPtr<FJsonObject> ClaireonTool_GasActivateAbility::GetInputSchema() const
+{
+	TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+	Schema->SetStringField(TEXT("type"), TEXT("object"));
+
+	TSharedPtr<FJsonObject> Properties = MakeShared<FJsonObject>();
+	ClaireonGasToolCommon::AddCommonSchemaParams(Properties);
+
+	TSharedPtr<FJsonObject> HandleProp = MakeShared<FJsonObject>();
+	HandleProp->SetStringField(TEXT("type"), TEXT("string"));
+	HandleProp->SetStringField(TEXT("description"),
+		TEXT("spec_handle_id from gas_runtime_inspect / gas_grant_ability. Activates exactly that spec."));
+	Properties->SetObjectField(TEXT("spec_handle_id"), HandleProp);
+
+	TSharedPtr<FJsonObject> NameProp = MakeShared<FJsonObject>();
+	NameProp->SetStringField(TEXT("type"), TEXT("string"));
+	NameProp->SetStringField(TEXT("description"),
+		TEXT("Substring matched against the actor's granted ability spec classes (e.g. 'GA_Jump')."));
+	Properties->SetObjectField(TEXT("ability_name"), NameProp);
+
+	Schema->SetObjectField(TEXT("properties"), Properties);
+
+	TArray<TSharedPtr<FJsonValue>> Required;
+	Required.Add(MakeShared<FJsonValueString>(TEXT("actorId")));
+	Schema->SetArrayField(TEXT("required"), Required);
+
+	return Schema;
+}
+
+IClaireonTool::FToolResult ClaireonTool_GasActivateAbility::Execute(const TSharedPtr<FJsonObject>& Arguments)
+{
+	ClaireonGasToolCommon::FGasTarget Target;
+	FString Error;
+	if (!ClaireonGasToolCommon::ResolveTarget(Arguments, Target, Error))
+	{
+		return MakeErrorResult(Error);
+	}
+	UAbilitySystemComponent* ASC = Target.ASC;
+
+	FString SpecHandleId;
+	const bool bHasHandle = Arguments->TryGetStringField(TEXT("spec_handle_id"), SpecHandleId) && !SpecHandleId.IsEmpty();
+	FString AbilityName;
+	const bool bHasName = Arguments->TryGetStringField(TEXT("ability_name"), AbilityName) && !AbilityName.IsEmpty();
+
+	if (!bHasHandle && !bHasName)
+	{
+		return MakeErrorResult(TEXT("Provide spec_handle_id or ability_name."));
+	}
+
+	// Locate the matching granted spec.
+	FGameplayAbilitySpecHandle MatchedHandle;
+	FString MatchedClass;
+	const UGameplayAbility* MatchedAbilityCDO = nullptr;
+	for (const FGameplayAbilitySpec& Spec : ASC->GetActivatableAbilities())
+	{
+		if (!Spec.Ability) { continue; }
+		const bool bMatch = bHasHandle
+			? Spec.Handle.ToString() == SpecHandleId
+			: Spec.Ability->GetClass()->GetName().Contains(AbilityName, ESearchCase::IgnoreCase);
+		if (bMatch)
+		{
+			MatchedHandle = Spec.Handle;
+			MatchedClass = Spec.Ability->GetClass()->GetName();
+			MatchedAbilityCDO = Spec.Ability;
+			break;
+		}
+	}
+
+	if (!MatchedHandle.IsValid())
+	{
+		return MakeErrorResult(FString::Printf(
+			TEXT("No granted ability matching %s on %s. Grant it first with gas_grant_ability."),
+			bHasHandle ? *FString::Printf(TEXT("spec_handle_id '%s'"), *SpecHandleId)
+			           : *FString::Printf(TEXT("ability_name '%s'"), *AbilityName),
+			*Target.Actor->GetName()));
+	}
+
+	const bool bActivated = ASC->TryActivateAbility(MatchedHandle);
+
+	FString Reason;
+	if (!bActivated && MatchedAbilityCDO)
+	{
+		// Best-effort explanation: re-run the can-activate check to collect the
+		// blocking tags. This mirrors pie_test_ability's dry-run diagnostic.
+		const FGameplayAbilityActorInfo* ActorInfo = ASC->AbilityActorInfo.Get();
+		FGameplayTagContainer FailureTags;
+		const bool bCanActivate = MatchedAbilityCDO->CanActivateAbility(
+			MatchedHandle, ActorInfo, nullptr, nullptr, &FailureTags);
+		if (bCanActivate)
+		{
+			Reason = TEXT("CanActivateAbility passed but TryActivateAbility returned false "
+				"(cost/cooldown committed elsewhere, or activation policy declined).");
+		}
+		else if (!FailureTags.IsEmpty())
+		{
+			Reason = FString::Printf(TEXT("Blocked by tags: %s"), *FailureTags.ToStringSimple());
+		}
+		else
+		{
+			Reason = TEXT("Blocked (CanActivateAbility returned false with no relevant tags).");
+		}
+	}
+
+	TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+	Data->SetStringField(TEXT("class"), MatchedClass);
+	Data->SetStringField(TEXT("spec_handle_id"), MatchedHandle.ToString());
+	Data->SetBoolField(TEXT("activated"), bActivated);
+	Data->SetStringField(TEXT("reason"), Reason);
+
+	const FString Summary = bActivated
+		? FString::Printf(TEXT("Activated %s on %s"), *MatchedClass, *Target.Actor->GetName())
+		: FString::Printf(TEXT("%s did not activate on %s: %s"), *MatchedClass, *Target.Actor->GetName(), *Reason);
+
+	return MakeSuccessResult(Data, Summary);
+}

--- a/Source/Claireon/Private/Tools/ClaireonTool_GasApplyEffect.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_GasApplyEffect.cpp
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#include "Tools/ClaireonTool_GasApplyEffect.h"
+
+#include "ClaireonGasToolCommon.h"
+
+#include "AbilitySystemComponent.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "GameFramework/Actor.h"
+#include "GameplayEffect.h"
+#include "GameplayEffectTypes.h"
+#include "GameplayTagContainer.h"
+
+FString ClaireonTool_GasApplyEffect::GetCategory() const { return TEXT("gas"); }
+FString ClaireonTool_GasApplyEffect::GetOperation() const { return TEXT("apply_effect"); }
+
+FString ClaireonTool_GasApplyEffect::GetDescription() const
+{
+	return TEXT("Apply a GameplayEffect to a live PIE actor's ASC. Identify the GE by effect_class_path "
+		"(authoritative, e.g. '/Game/.../GE_X.GE_X_C') or effect_name (substring of a loaded GE class). "
+		"Supports level, SetByCaller magnitudes, and a duration override (HasDuration policy only). "
+		"Defaults to the server (authoritative) world so the effect replicates. Returns a stable "
+		"effect_handle_id for gas_remove_effect. Requires PIE.");
+}
+
+EClaireonToolSessionMode ClaireonTool_GasApplyEffect::GetSessionMode() const
+{
+	return EClaireonToolSessionMode::ReadOnly;
+}
+
+TSharedPtr<FJsonObject> ClaireonTool_GasApplyEffect::GetInputSchema() const
+{
+	TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+	Schema->SetStringField(TEXT("type"), TEXT("object"));
+
+	TSharedPtr<FJsonObject> Properties = MakeShared<FJsonObject>();
+	ClaireonGasToolCommon::AddCommonSchemaParams(Properties);
+
+	TSharedPtr<FJsonObject> PathProp = MakeShared<FJsonObject>();
+	PathProp->SetStringField(TEXT("type"), TEXT("string"));
+	PathProp->SetStringField(TEXT("description"),
+		TEXT("Authoritative generated-class path of the GameplayEffect, e.g. "
+			 "'/Game/BP/Progression/Aspects/Seismic/GE_Seismic1.GE_Seismic1_C'."));
+	Properties->SetObjectField(TEXT("effect_class_path"), PathProp);
+
+	TSharedPtr<FJsonObject> NameProp = MakeShared<FJsonObject>();
+	NameProp->SetStringField(TEXT("type"), TEXT("string"));
+	NameProp->SetStringField(TEXT("description"),
+		TEXT("Convenience substring matched against loaded UGameplayEffect subclasses. "
+			 "Errors if ambiguous or not loaded; prefer effect_class_path."));
+	Properties->SetObjectField(TEXT("effect_name"), NameProp);
+
+	TSharedPtr<FJsonObject> LevelProp = MakeShared<FJsonObject>();
+	LevelProp->SetStringField(TEXT("type"), TEXT("number"));
+	LevelProp->SetStringField(TEXT("description"), TEXT("Effect level (default 1)."));
+	Properties->SetObjectField(TEXT("level"), LevelProp);
+
+	TSharedPtr<FJsonObject> MagsProp = MakeShared<FJsonObject>();
+	MagsProp->SetStringField(TEXT("type"), TEXT("object"));
+	MagsProp->SetStringField(TEXT("description"),
+		TEXT("Optional SetByCaller magnitudes: { \"<GameplayTag>\": <number> }. Aspects use these "
+			 "for damage numbers etc. Keys must be registered gameplay tags."));
+	Properties->SetObjectField(TEXT("magnitudes"), MagsProp);
+
+	TSharedPtr<FJsonObject> DurProp = MakeShared<FJsonObject>();
+	DurProp->SetStringField(TEXT("type"), TEXT("number"));
+	DurProp->SetStringField(TEXT("description"),
+		TEXT("Optional duration override in seconds. Only meaningful for a HasDuration effect."));
+	Properties->SetObjectField(TEXT("duration_override"), DurProp);
+
+	Schema->SetObjectField(TEXT("properties"), Properties);
+
+	TArray<TSharedPtr<FJsonValue>> Required;
+	Required.Add(MakeShared<FJsonValueString>(TEXT("actorId")));
+	Schema->SetArrayField(TEXT("required"), Required);
+
+	return Schema;
+}
+
+IClaireonTool::FToolResult ClaireonTool_GasApplyEffect::Execute(const TSharedPtr<FJsonObject>& Arguments)
+{
+	ClaireonGasToolCommon::FGasTarget Target;
+	FString Error;
+	if (!ClaireonGasToolCommon::ResolveTarget(Arguments, Target, Error))
+	{
+		return MakeErrorResult(Error);
+	}
+	UAbilitySystemComponent* ASC = Target.ASC;
+
+	TSubclassOf<UGameplayEffect> GEClass = ClaireonGasToolCommon::ResolveEffectClass(Arguments, Error);
+	if (!GEClass)
+	{
+		return MakeErrorResult(Error);
+	}
+
+	double LevelValue = 1.0;
+	Arguments->TryGetNumberField(TEXT("level"), LevelValue);
+	const float Level = static_cast<float>(LevelValue);
+
+	FGameplayEffectContextHandle Context = ASC->MakeEffectContext();
+	FGameplayEffectSpecHandle Spec = ASC->MakeOutgoingSpec(GEClass, Level, Context);
+	if (!Spec.IsValid() || !Spec.Data.IsValid())
+	{
+		return MakeErrorResult(FString::Printf(
+			TEXT("Failed to build an outgoing spec for effect '%s'."), *GEClass->GetName()));
+	}
+
+	TArray<FString> Warnings;
+
+	// SetByCaller magnitudes.
+	const TSharedPtr<FJsonObject>* MagnitudesObj = nullptr;
+	if (Arguments->TryGetObjectField(TEXT("magnitudes"), MagnitudesObj) && MagnitudesObj && MagnitudesObj->IsValid())
+	{
+		for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*MagnitudesObj)->Values)
+		{
+			double MagValue = 0.0;
+			if (!Pair.Value.IsValid() || !Pair.Value->TryGetNumber(MagValue))
+			{
+				Warnings.Add(FString::Printf(TEXT("magnitudes['%s'] is not a number; skipped."), *Pair.Key));
+				continue;
+			}
+			const FGameplayTag Tag = FGameplayTag::RequestGameplayTag(FName(*Pair.Key), /*ErrorIfNotFound=*/false);
+			if (!Tag.IsValid())
+			{
+				Warnings.Add(FString::Printf(TEXT("magnitude tag '%s' is not a registered gameplay tag; skipped."), *Pair.Key));
+				continue;
+			}
+			Spec.Data->SetSetByCallerMagnitude(Tag, static_cast<float>(MagValue));
+		}
+	}
+
+	// Optional duration override.
+	double DurationOverride = 0.0;
+	if (Arguments->TryGetNumberField(TEXT("duration_override"), DurationOverride))
+	{
+		if (Spec.Data->Def && Spec.Data->Def->DurationPolicy == EGameplayEffectDurationType::HasDuration)
+		{
+			Spec.Data->SetDuration(static_cast<float>(DurationOverride), /*bLockDuration=*/true);
+		}
+		else
+		{
+			Warnings.Add(TEXT("duration_override ignored: effect is not a HasDuration effect."));
+		}
+	}
+
+	if (!ASC->IsOwnerActorAuthoritative())
+	{
+		Warnings.Add(TEXT("ASC is not authoritative (client world); effect is client-predicted only. "
+			"Pass net_mode='server' to apply the authoritative effect."));
+	}
+
+	const FActiveGameplayEffectHandle Handle = ASC->ApplyGameplayEffectSpecToSelf(*Spec.Data.Get());
+
+	TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+	Data->SetStringField(TEXT("class"), GEClass->GetName());
+	Data->SetBoolField(TEXT("applied"), Handle.WasSuccessfullyApplied() || Handle.IsValid());
+	// Instant effects apply without leaving a persistent handle -> empty id.
+	Data->SetStringField(TEXT("effect_handle_id"), Handle.IsValid() ? Handle.ToString() : FString());
+
+	FGameplayTagContainer GrantedTags;
+	Spec.Data->GetAllGrantedTags(GrantedTags);
+	TArray<TSharedPtr<FJsonValue>> GrantedJson;
+	for (const FGameplayTag& Tag : GrantedTags)
+	{
+		GrantedJson.Add(MakeShared<FJsonValueString>(Tag.ToString()));
+	}
+	Data->SetArrayField(TEXT("granted_tags"), GrantedJson);
+
+	FString Summary;
+	if (Handle.IsValid())
+	{
+		Summary = FString::Printf(TEXT("Applied %s (handle %s) to %s"),
+			*GEClass->GetName(), *Handle.ToString(), *Target.Actor->GetName());
+	}
+	else if (Handle.WasSuccessfullyApplied())
+	{
+		Summary = FString::Printf(TEXT("Applied instant effect %s to %s (no persistent handle)"),
+			*GEClass->GetName(), *Target.Actor->GetName());
+	}
+	else
+	{
+		Summary = FString::Printf(TEXT("Effect %s did not apply to %s (filtered by application rules)"),
+			*GEClass->GetName(), *Target.Actor->GetName());
+	}
+
+	FToolResult Result = MakeSuccessResult(Data, Summary);
+	Result.Warnings = MoveTemp(Warnings);
+	return Result;
+}

--- a/Source/Claireon/Private/Tools/ClaireonTool_GasGrantAbility.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_GasGrantAbility.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#include "Tools/ClaireonTool_GasGrantAbility.h"
+
+#include "ClaireonGasToolCommon.h"
+
+#include "AbilitySystemComponent.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "GameFramework/Actor.h"
+#include "GameplayAbilitySpec.h"
+#include "Abilities/GameplayAbility.h"
+
+FString ClaireonTool_GasGrantAbility::GetCategory() const { return TEXT("gas"); }
+FString ClaireonTool_GasGrantAbility::GetOperation() const { return TEXT("grant_ability"); }
+
+FString ClaireonTool_GasGrantAbility::GetDescription() const
+{
+	return TEXT("Grant a GameplayAbility to a live PIE actor's ASC (requires the server/authoritative "
+		"world -- GiveAbility is authority-only). Identify the GA by ability_class_path or ability_name. "
+		"Optional level (default 1) and activate (default false). Returns spec_handle_id for "
+		"gas_activate_ability. Requires PIE.");
+}
+
+EClaireonToolSessionMode ClaireonTool_GasGrantAbility::GetSessionMode() const
+{
+	return EClaireonToolSessionMode::ReadOnly;
+}
+
+TSharedPtr<FJsonObject> ClaireonTool_GasGrantAbility::GetInputSchema() const
+{
+	TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+	Schema->SetStringField(TEXT("type"), TEXT("object"));
+
+	TSharedPtr<FJsonObject> Properties = MakeShared<FJsonObject>();
+	ClaireonGasToolCommon::AddCommonSchemaParams(Properties);
+
+	TSharedPtr<FJsonObject> PathProp = MakeShared<FJsonObject>();
+	PathProp->SetStringField(TEXT("type"), TEXT("string"));
+	PathProp->SetStringField(TEXT("description"),
+		TEXT("Authoritative generated-class path of the GameplayAbility, e.g. "
+			 "'/Game/.../GA_X.GA_X_C'."));
+	Properties->SetObjectField(TEXT("ability_class_path"), PathProp);
+
+	TSharedPtr<FJsonObject> NameProp = MakeShared<FJsonObject>();
+	NameProp->SetStringField(TEXT("type"), TEXT("string"));
+	NameProp->SetStringField(TEXT("description"),
+		TEXT("Convenience substring matched against loaded UGameplayAbility subclasses. "
+			 "Errors if ambiguous or not loaded; prefer ability_class_path."));
+	Properties->SetObjectField(TEXT("ability_name"), NameProp);
+
+	TSharedPtr<FJsonObject> LevelProp = MakeShared<FJsonObject>();
+	LevelProp->SetStringField(TEXT("type"), TEXT("number"));
+	LevelProp->SetStringField(TEXT("description"), TEXT("Ability level (default 1)."));
+	Properties->SetObjectField(TEXT("level"), LevelProp);
+
+	TSharedPtr<FJsonObject> ActivateProp = MakeShared<FJsonObject>();
+	ActivateProp->SetStringField(TEXT("type"), TEXT("boolean"));
+	ActivateProp->SetStringField(TEXT("description"), TEXT("Activate immediately after granting (default false)."));
+	Properties->SetObjectField(TEXT("activate"), ActivateProp);
+
+	Schema->SetObjectField(TEXT("properties"), Properties);
+
+	TArray<TSharedPtr<FJsonValue>> Required;
+	Required.Add(MakeShared<FJsonValueString>(TEXT("actorId")));
+	Schema->SetArrayField(TEXT("required"), Required);
+
+	return Schema;
+}
+
+IClaireonTool::FToolResult ClaireonTool_GasGrantAbility::Execute(const TSharedPtr<FJsonObject>& Arguments)
+{
+	ClaireonGasToolCommon::FGasTarget Target;
+	FString Error;
+	if (!ClaireonGasToolCommon::ResolveTarget(Arguments, Target, Error))
+	{
+		return MakeErrorResult(Error);
+	}
+	UAbilitySystemComponent* ASC = Target.ASC;
+
+	if (!ASC->IsOwnerActorAuthoritative())
+	{
+		return MakeErrorResult(TEXT("gas_grant_ability requires the authoritative ASC. This resolved to a "
+			"non-authority (client) world. Re-run with net_mode='server'."));
+	}
+
+	TSubclassOf<UGameplayAbility> AbilityClass = ClaireonGasToolCommon::ResolveAbilityClass(Arguments, Error);
+	if (!AbilityClass)
+	{
+		return MakeErrorResult(Error);
+	}
+
+	double LevelValue = 1.0;
+	Arguments->TryGetNumberField(TEXT("level"), LevelValue);
+	const int32 Level = static_cast<int32>(LevelValue);
+
+	bool bActivate = false;
+	Arguments->TryGetBoolField(TEXT("activate"), bActivate);
+
+	FGameplayAbilitySpec Spec(AbilityClass, Level, INDEX_NONE, /*SourceObject=*/nullptr);
+	const FGameplayAbilitySpecHandle Handle = ASC->GiveAbility(Spec);
+	if (!Handle.IsValid())
+	{
+		return MakeErrorResult(FString::Printf(
+			TEXT("GiveAbility failed for '%s' on %s."), *AbilityClass->GetName(), *Target.Actor->GetName()));
+	}
+
+	bool bActivated = false;
+	if (bActivate)
+	{
+		bActivated = ASC->TryActivateAbility(Handle);
+	}
+
+	TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+	Data->SetStringField(TEXT("spec_handle_id"), Handle.ToString());
+	Data->SetStringField(TEXT("class"), AbilityClass->GetName());
+	Data->SetBoolField(TEXT("activated"), bActivated);
+
+	FString Summary = FString::Printf(TEXT("Granted %s (handle %s) to %s"),
+		*AbilityClass->GetName(), *Handle.ToString(), *Target.Actor->GetName());
+	if (bActivate)
+	{
+		Summary += bActivated ? TEXT(" and activated it") : TEXT(" (activation blocked)");
+	}
+
+	return MakeSuccessResult(Data, Summary);
+}

--- a/Source/Claireon/Private/Tools/ClaireonTool_GasInspect.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_GasInspect.cpp
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#include "Tools/ClaireonTool_GasInspect.h"
+
+#include "ClaireonGasToolCommon.h"
+
+#include "AbilitySystemComponent.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "GameplayAbilitySpec.h"
+#include "GameplayEffect.h"
+#include "Abilities/GameplayAbility.h"
+
+FString ClaireonTool_GasInspect::GetCategory() const { return TEXT("gas"); }
+// "runtime_inspect" (not "inspect") so host projects can register an asset-side
+// GAS inspector as gas_inspect without colliding with this runtime ASC snapshot.
+// Parallels the statetree_runtime_inspect naming.
+FString ClaireonTool_GasInspect::GetOperation() const { return TEXT("runtime_inspect"); }
+
+FString ClaireonTool_GasInspect::GetDescription() const
+{
+	return TEXT("Full snapshot of a live PIE actor's AbilitySystemComponent: granted abilities, "
+		"active gameplay effects (with stable effect_handle_id for gas_remove_effect), attributes "
+		"(base + current), and owned gameplay tags. Defaults to the server (authoritative) world; "
+		"pass net_mode='client' to inspect client-side prediction. Read-only; requires PIE.");
+}
+
+EClaireonToolSessionMode ClaireonTool_GasInspect::GetSessionMode() const
+{
+	return EClaireonToolSessionMode::ReadOnly;
+}
+
+TSharedPtr<FJsonObject> ClaireonTool_GasInspect::GetInputSchema() const
+{
+	TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+	Schema->SetStringField(TEXT("type"), TEXT("object"));
+
+	TSharedPtr<FJsonObject> Properties = MakeShared<FJsonObject>();
+	ClaireonGasToolCommon::AddCommonSchemaParams(Properties);
+
+	// Optional sections filter.
+	TSharedPtr<FJsonObject> SectionsProp = MakeShared<FJsonObject>();
+	SectionsProp->SetStringField(TEXT("type"), TEXT("array"));
+	SectionsProp->SetStringField(TEXT("description"),
+		TEXT("Optional subset of sections to return. Any of 'abilities', 'effects', 'attributes', "
+			 "'tags'. Default: all four."));
+	TSharedPtr<FJsonObject> SectionsItems = MakeShared<FJsonObject>();
+	SectionsItems->SetStringField(TEXT("type"), TEXT("string"));
+	SectionsProp->SetObjectField(TEXT("items"), SectionsItems);
+	Properties->SetObjectField(TEXT("sections"), SectionsProp);
+
+	Schema->SetObjectField(TEXT("properties"), Properties);
+
+	TArray<TSharedPtr<FJsonValue>> Required;
+	Required.Add(MakeShared<FJsonValueString>(TEXT("actorId")));
+	Schema->SetArrayField(TEXT("required"), Required);
+
+	return Schema;
+}
+
+IClaireonTool::FToolResult ClaireonTool_GasInspect::Execute(const TSharedPtr<FJsonObject>& Arguments)
+{
+	ClaireonGasToolCommon::FGasTarget Target;
+	FString Error;
+	if (!ClaireonGasToolCommon::ResolveTarget(Arguments, Target, Error))
+	{
+		return MakeErrorResult(Error);
+	}
+	UAbilitySystemComponent* ASC = Target.ASC;
+
+	// Section selection (default all).
+	bool bWantAbilities = true, bWantEffects = true, bWantAttributes = true, bWantTags = true;
+	const TArray<TSharedPtr<FJsonValue>>* SectionsArray = nullptr;
+	if (Arguments->TryGetArrayField(TEXT("sections"), SectionsArray) && SectionsArray)
+	{
+		bWantAbilities = bWantEffects = bWantAttributes = bWantTags = false;
+		for (const TSharedPtr<FJsonValue>& Value : *SectionsArray)
+		{
+			const FString Section = Value->AsString();
+			if (Section.Equals(TEXT("abilities"), ESearchCase::IgnoreCase)) { bWantAbilities = true; }
+			else if (Section.Equals(TEXT("effects"), ESearchCase::IgnoreCase)) { bWantEffects = true; }
+			else if (Section.Equals(TEXT("attributes"), ESearchCase::IgnoreCase)) { bWantAttributes = true; }
+			else if (Section.Equals(TEXT("tags"), ESearchCase::IgnoreCase)) { bWantTags = true; }
+		}
+	}
+
+	TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+	int32 AbilityCount = 0, EffectCount = 0, AttributeCount = 0, TagCount = 0;
+
+	if (bWantAbilities)
+	{
+		TArray<TSharedPtr<FJsonValue>> AbilitiesJson;
+		for (const FGameplayAbilitySpec& Spec : ASC->GetActivatableAbilities())
+		{
+			if (!Spec.Ability) { continue; }
+			TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+			Obj->SetStringField(TEXT("class"), Spec.Ability->GetClass()->GetName());
+			Obj->SetStringField(TEXT("spec_handle_id"), Spec.Handle.ToString());
+			Obj->SetNumberField(TEXT("level"), Spec.Level);
+			Obj->SetNumberField(TEXT("input_id"), Spec.InputID);
+			Obj->SetBoolField(TEXT("is_active"), Spec.IsActive());
+			const UObject* Source = Spec.SourceObject.Get();
+			Obj->SetStringField(TEXT("source_object"), Source ? Source->GetName() : TEXT(""));
+			AbilitiesJson.Add(MakeShared<FJsonValueObject>(Obj));
+		}
+		AbilityCount = AbilitiesJson.Num();
+		Data->SetArrayField(TEXT("abilities"), AbilitiesJson);
+	}
+
+	if (bWantEffects)
+	{
+		const float WorldTime = Target.World ? Target.World->GetTimeSeconds() : 0.0f;
+		TArray<TSharedPtr<FJsonValue>> EffectsJson;
+		TArray<FActiveGameplayEffectHandle> Handles = ASC->GetActiveEffects(FGameplayEffectQuery());
+		for (const FActiveGameplayEffectHandle& Handle : Handles)
+		{
+			const FActiveGameplayEffect* Active = ASC->GetActiveGameplayEffect(Handle);
+			if (!Active || !Active->Spec.Def) { continue; }
+			TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+			Obj->SetStringField(TEXT("effect_handle_id"), Handle.ToString());
+			Obj->SetStringField(TEXT("class"), Active->Spec.Def->GetClass()->GetName());
+			Obj->SetNumberField(TEXT("duration_remaining"), Active->GetTimeRemaining(WorldTime));
+			Obj->SetNumberField(TEXT("total_duration"), Active->GetDuration());
+			Obj->SetNumberField(TEXT("stacks"), Active->Spec.GetStackCount());
+			Obj->SetNumberField(TEXT("level"), Active->Spec.GetLevel());
+
+			FGameplayTagContainer GrantedTags;
+			Active->Spec.GetAllGrantedTags(GrantedTags);
+			TArray<TSharedPtr<FJsonValue>> GrantedJson;
+			for (const FGameplayTag& Tag : GrantedTags)
+			{
+				GrantedJson.Add(MakeShared<FJsonValueString>(Tag.ToString()));
+			}
+			Obj->SetArrayField(TEXT("granted_tags"), GrantedJson);
+
+			const UObject* Source = Active->Spec.GetContext().GetSourceObject();
+			Obj->SetStringField(TEXT("source"), Source ? Source->GetName() : TEXT(""));
+			EffectsJson.Add(MakeShared<FJsonValueObject>(Obj));
+		}
+		EffectCount = EffectsJson.Num();
+		Data->SetArrayField(TEXT("active_effects"), EffectsJson);
+	}
+
+	if (bWantAttributes)
+	{
+		TArray<FGameplayAttribute> Attributes;
+		ASC->GetAllAttributes(Attributes);
+		TArray<TSharedPtr<FJsonValue>> AttrsJson;
+		for (const FGameplayAttribute& Attr : Attributes)
+		{
+			if (!Attr.IsValid()) { continue; }
+			TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+			const UClass* SetClass = Attr.GetAttributeSetClass();
+			Obj->SetStringField(TEXT("set"), SetClass ? SetClass->GetName() : TEXT(""));
+			Obj->SetStringField(TEXT("name"), Attr.GetName());
+			Obj->SetNumberField(TEXT("base_value"), ASC->GetNumericAttributeBase(Attr));
+			Obj->SetNumberField(TEXT("current_value"), ASC->GetNumericAttribute(Attr));
+			AttrsJson.Add(MakeShared<FJsonValueObject>(Obj));
+		}
+		AttributeCount = AttrsJson.Num();
+		Data->SetArrayField(TEXT("attributes"), AttrsJson);
+	}
+
+	if (bWantTags)
+	{
+		FGameplayTagContainer OwnedTags;
+		ASC->GetOwnedGameplayTags(OwnedTags);
+		TArray<TSharedPtr<FJsonValue>> TagsJson;
+		for (const FGameplayTag& Tag : OwnedTags)
+		{
+			TagsJson.Add(MakeShared<FJsonValueString>(Tag.ToString()));
+		}
+		TagCount = TagsJson.Num();
+		Data->SetArrayField(TEXT("owned_tags"), TagsJson);
+	}
+
+	const FString Summary = FString::Printf(
+		TEXT("%d abilities, %d effects, %d attributes, %d tags on %s"),
+		AbilityCount, EffectCount, AttributeCount, TagCount, *Target.Actor->GetName());
+
+	return MakeSuccessResult(Data, Summary);
+}

--- a/Source/Claireon/Private/Tools/ClaireonTool_GasRemoveEffect.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_GasRemoveEffect.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#include "Tools/ClaireonTool_GasRemoveEffect.h"
+
+#include "ClaireonGasToolCommon.h"
+
+#include "AbilitySystemComponent.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "GameFramework/Actor.h"
+#include "GameplayEffect.h"
+#include "GameplayEffectTypes.h"
+
+FString ClaireonTool_GasRemoveEffect::GetCategory() const { return TEXT("gas"); }
+FString ClaireonTool_GasRemoveEffect::GetOperation() const { return TEXT("remove_effect"); }
+
+FString ClaireonTool_GasRemoveEffect::GetDescription() const
+{
+	return TEXT("Remove an applied GameplayEffect from a live PIE actor's ASC. Address it by "
+		"effect_handle_id (from gas_runtime_inspect / gas_apply_effect) to remove one, or by "
+		"effect_class_path / effect_name to remove all matching. Optional stacks_to_remove "
+		"(default -1 = all stacks). Defaults to the server world. Requires PIE.");
+}
+
+EClaireonToolSessionMode ClaireonTool_GasRemoveEffect::GetSessionMode() const
+{
+	return EClaireonToolSessionMode::ReadOnly;
+}
+
+TSharedPtr<FJsonObject> ClaireonTool_GasRemoveEffect::GetInputSchema() const
+{
+	TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+	Schema->SetStringField(TEXT("type"), TEXT("object"));
+
+	TSharedPtr<FJsonObject> Properties = MakeShared<FJsonObject>();
+	ClaireonGasToolCommon::AddCommonSchemaParams(Properties);
+
+	TSharedPtr<FJsonObject> HandleProp = MakeShared<FJsonObject>();
+	HandleProp->SetStringField(TEXT("type"), TEXT("string"));
+	HandleProp->SetStringField(TEXT("description"),
+		TEXT("effect_handle_id from gas_runtime_inspect / gas_apply_effect. Removes exactly that effect."));
+	Properties->SetObjectField(TEXT("effect_handle_id"), HandleProp);
+
+	TSharedPtr<FJsonObject> PathProp = MakeShared<FJsonObject>();
+	PathProp->SetStringField(TEXT("type"), TEXT("string"));
+	PathProp->SetStringField(TEXT("description"),
+		TEXT("Generated-class path of the GameplayEffect; removes ALL active effects of this class."));
+	Properties->SetObjectField(TEXT("effect_class_path"), PathProp);
+
+	TSharedPtr<FJsonObject> NameProp = MakeShared<FJsonObject>();
+	NameProp->SetStringField(TEXT("type"), TEXT("string"));
+	NameProp->SetStringField(TEXT("description"),
+		TEXT("Substring matched against loaded UGameplayEffect subclasses; removes ALL matching."));
+	Properties->SetObjectField(TEXT("effect_name"), NameProp);
+
+	TSharedPtr<FJsonObject> StacksProp = MakeShared<FJsonObject>();
+	StacksProp->SetStringField(TEXT("type"), TEXT("number"));
+	StacksProp->SetStringField(TEXT("description"), TEXT("Stacks to remove (default -1 = all)."));
+	Properties->SetObjectField(TEXT("stacks_to_remove"), StacksProp);
+
+	Schema->SetObjectField(TEXT("properties"), Properties);
+
+	TArray<TSharedPtr<FJsonValue>> Required;
+	Required.Add(MakeShared<FJsonValueString>(TEXT("actorId")));
+	Schema->SetArrayField(TEXT("required"), Required);
+
+	return Schema;
+}
+
+IClaireonTool::FToolResult ClaireonTool_GasRemoveEffect::Execute(const TSharedPtr<FJsonObject>& Arguments)
+{
+	ClaireonGasToolCommon::FGasTarget Target;
+	FString Error;
+	if (!ClaireonGasToolCommon::ResolveTarget(Arguments, Target, Error))
+	{
+		return MakeErrorResult(Error);
+	}
+	UAbilitySystemComponent* ASC = Target.ASC;
+
+	int32 StacksToRemove = -1;
+	double StacksValue = 0.0;
+	if (Arguments->TryGetNumberField(TEXT("stacks_to_remove"), StacksValue))
+	{
+		StacksToRemove = static_cast<int32>(StacksValue);
+	}
+
+	int32 RemovedCount = 0;
+
+	FString HandleId;
+	const bool bHasHandle = Arguments->TryGetStringField(TEXT("effect_handle_id"), HandleId) && !HandleId.IsEmpty();
+	const bool bHasClass = Arguments->HasField(TEXT("effect_class_path")) || Arguments->HasField(TEXT("effect_name"));
+
+	if (bHasHandle)
+	{
+		if (!HandleId.IsNumeric())
+		{
+			return MakeErrorResult(FString::Printf(
+				TEXT("effect_handle_id '%s' is not a valid handle (expected the integer id from gas_runtime_inspect)."),
+				*HandleId));
+		}
+		const FActiveGameplayEffectHandle Handle(FCString::Atoi(*HandleId));
+		if (!ASC->GetActiveGameplayEffect(Handle))
+		{
+			return MakeErrorResult(FString::Printf(
+				TEXT("No active effect with handle '%s' on %s (already expired or wrong world/actor?)."),
+				*HandleId, *Target.Actor->GetName()));
+		}
+		if (ASC->RemoveActiveGameplayEffect(Handle, StacksToRemove))
+		{
+			RemovedCount = 1;
+		}
+	}
+	else if (bHasClass)
+	{
+		TSubclassOf<UGameplayEffect> GEClass = ClaireonGasToolCommon::ResolveEffectClass(Arguments, Error);
+		if (!GEClass)
+		{
+			return MakeErrorResult(Error);
+		}
+		// Snapshot handles first: removal mutates the active-effects container.
+		TArray<FActiveGameplayEffectHandle> ToRemove;
+		for (const FActiveGameplayEffectHandle& Handle : ASC->GetActiveEffects(FGameplayEffectQuery()))
+		{
+			const FActiveGameplayEffect* Active = ASC->GetActiveGameplayEffect(Handle);
+			if (Active && Active->Spec.Def && Active->Spec.Def->GetClass()->IsChildOf(GEClass))
+			{
+				ToRemove.Add(Handle);
+			}
+		}
+		for (const FActiveGameplayEffectHandle& Handle : ToRemove)
+		{
+			if (ASC->RemoveActiveGameplayEffect(Handle, StacksToRemove))
+			{
+				++RemovedCount;
+			}
+		}
+	}
+	else
+	{
+		return MakeErrorResult(TEXT("Provide effect_handle_id, or effect_class_path / effect_name."));
+	}
+
+	TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+	Data->SetNumberField(TEXT("removed_count"), RemovedCount);
+
+	const FString Summary = FString::Printf(TEXT("Removed %d effect(s) from %s"),
+		RemovedCount, *Target.Actor->GetName());
+	return MakeSuccessResult(Data, Summary);
+}

--- a/Source/Claireon/Private/Tools/ClaireonTool_GasSetAttribute.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_GasSetAttribute.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#include "Tools/ClaireonTool_GasSetAttribute.h"
+
+#include "ClaireonGasToolCommon.h"
+
+#include "AbilitySystemComponent.h"
+#include "AttributeSet.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "GameFramework/Actor.h"
+#include "GameplayEffectTypes.h"
+
+FString ClaireonTool_GasSetAttribute::GetCategory() const { return TEXT("gas"); }
+FString ClaireonTool_GasSetAttribute::GetOperation() const { return TEXT("set_attribute"); }
+
+FString ClaireonTool_GasSetAttribute::GetDescription() const
+{
+	return TEXT("Set a gameplay attribute's base or current value on a live PIE actor's ASC (e.g. drop "
+		"Health to test a threshold aspect). Args: attribute (name matched against the ASC's attributes), "
+		"value (number), mode ('base' or 'current', default base). Defaults to the server world. Returns "
+		"old_value and new_value. Requires PIE.");
+}
+
+EClaireonToolSessionMode ClaireonTool_GasSetAttribute::GetSessionMode() const
+{
+	return EClaireonToolSessionMode::ReadOnly;
+}
+
+TSharedPtr<FJsonObject> ClaireonTool_GasSetAttribute::GetInputSchema() const
+{
+	TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+	Schema->SetStringField(TEXT("type"), TEXT("object"));
+
+	TSharedPtr<FJsonObject> Properties = MakeShared<FJsonObject>();
+	ClaireonGasToolCommon::AddCommonSchemaParams(Properties);
+
+	TSharedPtr<FJsonObject> AttrProp = MakeShared<FJsonObject>();
+	AttrProp->SetStringField(TEXT("type"), TEXT("string"));
+	AttrProp->SetStringField(TEXT("description"),
+		TEXT("Attribute name matched against the ASC's attributes (exact case-insensitive, else unique "
+			 "substring), e.g. 'Health'."));
+	Properties->SetObjectField(TEXT("attribute"), AttrProp);
+
+	TSharedPtr<FJsonObject> ValueProp = MakeShared<FJsonObject>();
+	ValueProp->SetStringField(TEXT("type"), TEXT("number"));
+	ValueProp->SetStringField(TEXT("description"), TEXT("New value."));
+	Properties->SetObjectField(TEXT("value"), ValueProp);
+
+	TSharedPtr<FJsonObject> ModeProp = MakeShared<FJsonObject>();
+	ModeProp->SetStringField(TEXT("type"), TEXT("string"));
+	ModeProp->SetStringField(TEXT("description"),
+		TEXT("'base' sets the base value (SetNumericAttributeBase); 'current' overrides the current "
+			 "value (ApplyModToAttribute Override). Default 'base'."));
+	TArray<TSharedPtr<FJsonValue>> ModeEnum;
+	ModeEnum.Add(MakeShared<FJsonValueString>(TEXT("base")));
+	ModeEnum.Add(MakeShared<FJsonValueString>(TEXT("current")));
+	ModeProp->SetArrayField(TEXT("enum"), ModeEnum);
+	Properties->SetObjectField(TEXT("mode"), ModeProp);
+
+	Schema->SetObjectField(TEXT("properties"), Properties);
+
+	TArray<TSharedPtr<FJsonValue>> Required;
+	Required.Add(MakeShared<FJsonValueString>(TEXT("actorId")));
+	Required.Add(MakeShared<FJsonValueString>(TEXT("attribute")));
+	Required.Add(MakeShared<FJsonValueString>(TEXT("value")));
+	Schema->SetArrayField(TEXT("required"), Required);
+
+	return Schema;
+}
+
+IClaireonTool::FToolResult ClaireonTool_GasSetAttribute::Execute(const TSharedPtr<FJsonObject>& Arguments)
+{
+	ClaireonGasToolCommon::FGasTarget Target;
+	FString Error;
+	if (!ClaireonGasToolCommon::ResolveTarget(Arguments, Target, Error))
+	{
+		return MakeErrorResult(Error);
+	}
+	UAbilitySystemComponent* ASC = Target.ASC;
+
+	FString AttributeName;
+	if (!Arguments->TryGetStringField(TEXT("attribute"), AttributeName) || AttributeName.IsEmpty())
+	{
+		return MakeErrorResult(TEXT("Missing required argument: attribute"));
+	}
+
+	double Value = 0.0;
+	if (!Arguments->TryGetNumberField(TEXT("value"), Value))
+	{
+		return MakeErrorResult(TEXT("Missing required numeric argument: value"));
+	}
+
+	FGameplayAttribute Attribute;
+	if (!ClaireonGasToolCommon::ResolveAttribute(ASC, AttributeName, Attribute, Error))
+	{
+		return MakeErrorResult(Error);
+	}
+
+	FString Mode = TEXT("base");
+	Arguments->TryGetStringField(TEXT("mode"), Mode);
+	const bool bBase = !Mode.Equals(TEXT("current"), ESearchCase::IgnoreCase);
+
+	const float OldValue = bBase ? ASC->GetNumericAttributeBase(Attribute) : ASC->GetNumericAttribute(Attribute);
+
+	if (bBase)
+	{
+		ASC->SetNumericAttributeBase(Attribute, static_cast<float>(Value));
+	}
+	else
+	{
+		ASC->ApplyModToAttribute(Attribute, EGameplayModOp::Override, static_cast<float>(Value));
+	}
+
+	const float NewValue = bBase ? ASC->GetNumericAttributeBase(Attribute) : ASC->GetNumericAttribute(Attribute);
+
+	TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+	Data->SetStringField(TEXT("attribute"), ClaireonGasToolCommon::AttributeDisplayName(Attribute));
+	Data->SetStringField(TEXT("mode"), bBase ? TEXT("base") : TEXT("current"));
+	Data->SetNumberField(TEXT("old_value"), OldValue);
+	Data->SetNumberField(TEXT("new_value"), NewValue);
+
+	const FString Summary = FString::Printf(TEXT("%s %s: %.3f -> %.3f on %s"),
+		*ClaireonGasToolCommon::AttributeDisplayName(Attribute),
+		bBase ? TEXT("(base)") : TEXT("(current)"),
+		OldValue, NewValue, *Target.Actor->GetName());
+
+	return MakeSuccessResult(Data, Summary);
+}

--- a/Source/Claireon/Private/Tools/ClaireonTool_GasSetTags.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_GasSetTags.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#include "Tools/ClaireonTool_GasSetTags.h"
+
+#include "ClaireonGasToolCommon.h"
+
+#include "AbilitySystemComponent.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "GameFramework/Actor.h"
+#include "GameplayTagContainer.h"
+
+FString ClaireonTool_GasSetTags::GetCategory() const { return TEXT("gas"); }
+FString ClaireonTool_GasSetTags::GetOperation() const { return TEXT("set_tags"); }
+
+FString ClaireonTool_GasSetTags::GetDescription() const
+{
+	return TEXT("Add or remove loose gameplay tags on a live PIE actor's ASC -- simulate a trigger/state "
+		"condition (e.g. add a state tag so an aspect's HitModifier condition fires). Args: tags (array "
+		"of registered gameplay tag strings) and op ('add' or 'remove'). Defaults to the server world. "
+		"Returns the owned tags after the change. Requires PIE.");
+}
+
+EClaireonToolSessionMode ClaireonTool_GasSetTags::GetSessionMode() const
+{
+	return EClaireonToolSessionMode::ReadOnly;
+}
+
+TSharedPtr<FJsonObject> ClaireonTool_GasSetTags::GetInputSchema() const
+{
+	TSharedPtr<FJsonObject> Schema = MakeShared<FJsonObject>();
+	Schema->SetStringField(TEXT("type"), TEXT("object"));
+
+	TSharedPtr<FJsonObject> Properties = MakeShared<FJsonObject>();
+	ClaireonGasToolCommon::AddCommonSchemaParams(Properties);
+
+	TSharedPtr<FJsonObject> TagsProp = MakeShared<FJsonObject>();
+	TagsProp->SetStringField(TEXT("type"), TEXT("array"));
+	TagsProp->SetStringField(TEXT("description"),
+		TEXT("Gameplay tag strings to add/remove (must be registered tags, e.g. 'State.Grappling')."));
+	TSharedPtr<FJsonObject> TagsItems = MakeShared<FJsonObject>();
+	TagsItems->SetStringField(TEXT("type"), TEXT("string"));
+	TagsProp->SetObjectField(TEXT("items"), TagsItems);
+	Properties->SetObjectField(TEXT("tags"), TagsProp);
+
+	TSharedPtr<FJsonObject> OpProp = MakeShared<FJsonObject>();
+	OpProp->SetStringField(TEXT("type"), TEXT("string"));
+	OpProp->SetStringField(TEXT("description"), TEXT("'add' or 'remove' (default 'add')."));
+	TArray<TSharedPtr<FJsonValue>> OpEnum;
+	OpEnum.Add(MakeShared<FJsonValueString>(TEXT("add")));
+	OpEnum.Add(MakeShared<FJsonValueString>(TEXT("remove")));
+	OpProp->SetArrayField(TEXT("enum"), OpEnum);
+	Properties->SetObjectField(TEXT("op"), OpProp);
+
+	Schema->SetObjectField(TEXT("properties"), Properties);
+
+	TArray<TSharedPtr<FJsonValue>> Required;
+	Required.Add(MakeShared<FJsonValueString>(TEXT("actorId")));
+	Required.Add(MakeShared<FJsonValueString>(TEXT("tags")));
+	Schema->SetArrayField(TEXT("required"), Required);
+
+	return Schema;
+}
+
+IClaireonTool::FToolResult ClaireonTool_GasSetTags::Execute(const TSharedPtr<FJsonObject>& Arguments)
+{
+	ClaireonGasToolCommon::FGasTarget Target;
+	FString Error;
+	if (!ClaireonGasToolCommon::ResolveTarget(Arguments, Target, Error))
+	{
+		return MakeErrorResult(Error);
+	}
+	UAbilitySystemComponent* ASC = Target.ASC;
+
+	const TArray<TSharedPtr<FJsonValue>>* TagsArray = nullptr;
+	if (!Arguments->TryGetArrayField(TEXT("tags"), TagsArray) || !TagsArray || TagsArray->Num() == 0)
+	{
+		return MakeErrorResult(TEXT("Missing required argument: tags (non-empty array of tag strings)."));
+	}
+
+	FString Op = TEXT("add");
+	Arguments->TryGetStringField(TEXT("op"), Op);
+	const bool bAdd = !Op.Equals(TEXT("remove"), ESearchCase::IgnoreCase);
+
+	TArray<FString> Warnings;
+	int32 Changed = 0;
+	for (const TSharedPtr<FJsonValue>& Value : *TagsArray)
+	{
+		const FString TagString = Value->AsString();
+		if (TagString.IsEmpty()) { continue; }
+		const FGameplayTag Tag = FGameplayTag::RequestGameplayTag(FName(*TagString), /*ErrorIfNotFound=*/false);
+		if (!Tag.IsValid())
+		{
+			Warnings.Add(FString::Printf(TEXT("'%s' is not a registered gameplay tag; skipped."), *TagString));
+			continue;
+		}
+		if (bAdd)
+		{
+			ASC->AddLooseGameplayTag(Tag);
+		}
+		else
+		{
+			ASC->RemoveLooseGameplayTag(Tag);
+		}
+		++Changed;
+	}
+
+	FGameplayTagContainer OwnedTags;
+	ASC->GetOwnedGameplayTags(OwnedTags);
+	TArray<TSharedPtr<FJsonValue>> OwnedJson;
+	for (const FGameplayTag& Tag : OwnedTags)
+	{
+		OwnedJson.Add(MakeShared<FJsonValueString>(Tag.ToString()));
+	}
+
+	TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+	Data->SetArrayField(TEXT("owned_tags_after"), OwnedJson);
+
+	const FString Summary = FString::Printf(TEXT("%s %d tag(s) on %s (%d owned now)"),
+		bAdd ? TEXT("Added") : TEXT("Removed"), Changed, *Target.Actor->GetName(), OwnedJson.Num());
+
+	FToolResult Result = MakeSuccessResult(Data, Summary);
+	Result.Warnings = MoveTemp(Warnings);
+	return Result;
+}

--- a/Source/Claireon/Private/Tools/ClaireonTool_PlaceActor.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_PlaceActor.cpp
@@ -387,7 +387,7 @@ FToolResult ClaireonTool_PlaceActor::Execute(const TSharedPtr<FJsonObject>& Argu
 
 				ClaireonPropertyResolver::FResolvedProperty Resolved;
 				FString WriteError;
-				bool bOk = ClaireonPropertyResolver::WritePropertyOnActor(SpawnedActor, Pair.Key, ValueStr, Resolved, WriteError);
+				bool bOk = ClaireonPropertyResolver::WritePropertyOnActor(SpawnedActor, FString(*Pair.Key), ValueStr, Resolved, WriteError);
 				if (!bOk)
 				{
 					UE_LOG(LogClaireon, Warning, TEXT("[place_actor] %s"), *WriteError);

--- a/Source/Claireon/Private/Tools/ClaireonTool_ReplaceStructUsage.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_ReplaceStructUsage.cpp
@@ -308,7 +308,7 @@ FToolResult ClaireonTool_ReplaceStructUsage::Execute(const TSharedPtr<FJsonObjec
 			FString V;
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(V))
 			{
-				FieldMap.Add(Pair.Key, V);
+				FieldMap.Add(FString(*Pair.Key), V);
 			}
 		}
 	}

--- a/Source/Claireon/Private/Tools/ClaireonTool_TraceClose.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_TraceClose.cpp
@@ -37,12 +37,16 @@ TSharedPtr<FJsonObject> ClaireonTool_TraceClose::GetInputSchema() const
 IClaireonTool::FToolResult ClaireonTool_TraceClose::Execute(const TSharedPtr<FJsonObject>& Arguments)
 {
 	FString SessionId;
-	if (!Arguments->TryGetStringField(TEXT("sessionId"), SessionId) || SessionId.IsEmpty())
+	if (!Arguments.IsValid() || !Arguments->TryGetStringField(TEXT("sessionId"), SessionId) || SessionId.IsEmpty())
 	{
 		return MakeErrorResult(TEXT("Missing required field: sessionId"));
 	}
 
 	const bool bClosed = FClaireonTraceSessionManager::Get().CloseSession(SessionId);
+	if (!bClosed)
+	{
+		return MakeErrorResult(FString::Printf(TEXT("Trace session not found: %s"), *SessionId));
+	}
 
 	TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
 	Data->SetStringField(TEXT("session_id"), SessionId);

--- a/Source/Claireon/Private/Tools/ClaireonTool_TraceGetFrameStats.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_TraceGetFrameStats.cpp
@@ -143,7 +143,7 @@ TArray<FHitchScopeEntry> ReadScopesFromAggregation(
 IClaireonTool::FToolResult ClaireonTool_TraceGetFrameStats::Execute(const TSharedPtr<FJsonObject>& Arguments)
 {
 	FString SessionId;
-	if (!Arguments->TryGetStringField(TEXT("sessionId"), SessionId) || SessionId.IsEmpty())
+	if (!Arguments.IsValid() || !Arguments->TryGetStringField(TEXT("sessionId"), SessionId) || SessionId.IsEmpty())
 	{
 		return MakeErrorResult(TEXT("Missing required field: sessionId"));
 	}

--- a/Source/Claireon/Private/Tools/ClaireonTool_TraceGetScopeDetails.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_TraceGetScopeDetails.cpp
@@ -77,7 +77,7 @@ TSharedPtr<FJsonObject> ClaireonTool_TraceGetScopeDetails::GetInputSchema() cons
 IClaireonTool::FToolResult ClaireonTool_TraceGetScopeDetails::Execute(const TSharedPtr<FJsonObject>& Arguments)
 {
 	FString SessionId;
-	if (!Arguments->TryGetStringField(TEXT("sessionId"), SessionId) || SessionId.IsEmpty())
+	if (!Arguments.IsValid() || !Arguments->TryGetStringField(TEXT("sessionId"), SessionId) || SessionId.IsEmpty())
 	{
 		return MakeErrorResult(TEXT("Missing required field: sessionId"));
 	}

--- a/Source/Claireon/Private/Tools/ClaireonTool_TraceGetTopScopes.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_TraceGetTopScopes.cpp
@@ -106,7 +106,7 @@ TSharedPtr<FJsonObject> ClaireonTool_TraceGetTopScopes::GetInputSchema() const
 IClaireonTool::FToolResult ClaireonTool_TraceGetTopScopes::Execute(const TSharedPtr<FJsonObject>& Arguments)
 {
 	FString SessionId;
-	if (!Arguments->TryGetStringField(TEXT("sessionId"), SessionId) || SessionId.IsEmpty())
+	if (!Arguments.IsValid() || !Arguments->TryGetStringField(TEXT("sessionId"), SessionId) || SessionId.IsEmpty())
 	{
 		return MakeErrorResult(TEXT("Missing required field: sessionId"));
 	}

--- a/Source/Claireon/Private/Tools/ClaireonTool_TraceOpen.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonTool_TraceOpen.cpp
@@ -40,7 +40,7 @@ TSharedPtr<FJsonObject> ClaireonTool_TraceOpen::GetInputSchema() const
 IClaireonTool::FToolResult ClaireonTool_TraceOpen::Execute(const TSharedPtr<FJsonObject>& Arguments)
 {
 	FString FilePath;
-	if (!Arguments->TryGetStringField(TEXT("filePath"), FilePath) || FilePath.IsEmpty())
+	if (!Arguments.IsValid() || !Arguments->TryGetStringField(TEXT("filePath"), FilePath) || FilePath.IsEmpty())
 	{
 		return MakeErrorResult(TEXT("Missing required field: filePath"));
 	}

--- a/Source/Claireon/Private/Tools/ClaireonWidgetAnimationHandlers.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetAnimationHandlers.cpp
@@ -17,6 +17,7 @@
 #include "WidgetBlueprint.h"
 
 #include "Tools/ClaireonSequenceHelpers.h"
+#include "ClaireonWidgetHelpers.h"
 
 // ============================================================================
 // Widget-animation Apply handlers -- free functions used by the per-op
@@ -92,6 +93,7 @@ bool ApplyCreateAnimation(UWidgetBlueprint* WBP, const FString& AnimationName, f
 
 	WBP->Modify();
 	WBP->Animations.Add(NewAnim);
+	ClaireonWidgetHelpers::NotifyVariableAdded(WBP, NewAnim->GetFName());
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
 
 	OutAnim = NewAnim;
@@ -113,11 +115,13 @@ bool ApplyDeleteAnimation(UWidgetBlueprint* WBP, const FString& AnimationName, F
 		return false;
 	}
 	WBP->Modify();
+	const FName RemovedAnimName = Anim->GetFName();
 	// Engine pattern from AnimationTabSummoner::OnDeleteAnimation: reparent to
 	// transient package so the WBP no longer owns the asset. Avoids future name
 	// collisions; GC sweep reclaims it.
 	Anim->Rename(nullptr, GetTransientPackage(), REN_DontCreateRedirectors);
 	WBP->Animations.Remove(Anim);
+	ClaireonWidgetHelpers::NotifyVariableRemoved(WBP, RemovedAnimName);
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
 	return true;
 }
@@ -151,6 +155,12 @@ bool ApplyRenameAnimation(UWidgetBlueprint* WBP, const FString& OldName, const F
 
 	WBP->Modify();
 	Anim->Modify();
+
+	// Update the GUID bookkeeping before the object renames: Rename() broadcasts
+	// and can trigger an immediate recompile, whose validation expects the map to
+	// already know the new name.
+	ClaireonWidgetHelpers::NotifyVariableRenamed(WBP, OldFName, NewFName);
+
 	if (UMovieScene* MS = Anim->GetMovieScene())
 	{
 		MS->Modify();

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_AddMVVMViewModel.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_AddMVVMViewModel.cpp
@@ -105,9 +105,10 @@ FToolResult ClaireonWidgetBPTool_AddMVVMViewModel::Execute(const TSharedPtr<FJso
 	// Construct and add context
 	FScopedTransaction Transaction(FText::FromString(TEXT("[Claireon] Add MVVM ViewModel")));
 
-	FMVVMBlueprintViewModelContext Context;
-	Context.ViewModelName = FName(*ViewModelName);
-	Context.NotifyFieldValueClass = VMClass;
+	// Construct via the (class, name) constructor so a valid ViewModelContextId GUID is
+	// generated. Default-constructing and setting fields by hand leaves the GUID invalid,
+	// which UE 5.8 rejects at compile time ("Viewmodel 'X': GUID is invalid").
+	FMVVMBlueprintViewModelContext Context(VMClass, FName(*ViewModelName));
 	Context.CreationType = CreationType;
 	Context.bOptional = bOptional;
 

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_AddWidget.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_AddWidget.cpp
@@ -173,13 +173,13 @@ FToolResult ClaireonWidgetBPTool_AddWidget::Execute(const TSharedPtr<FJsonObject
 					// passing "" (what AsString() returns for object/array values).
 					FString PropStrVal;
 					FString PropConvErr;
-					if (!AddWidget_SlotPropJsonValueToString(Pair.Key, Pair.Value, PropStrVal, PropConvErr))
+					if (!AddWidget_SlotPropJsonValueToString(FString(*Pair.Key), Pair.Value, PropStrVal, PropConvErr))
 					{
 						UE_LOG(LogClaireon, Warning, TEXT("[EditWidgetBP] add_widget: %s"), *PropConvErr);
 						continue;
 					}
 					FString SlotError;
-					ClaireonWidgetHelpers::WriteSlotProperty(Slot, Pair.Key, PropStrVal, SlotError);
+					ClaireonWidgetHelpers::WriteSlotProperty(Slot, FString(*Pair.Key), PropStrVal, SlotError);
 				}
 			}
 		}

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_Create.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_Create.cpp
@@ -152,7 +152,7 @@ FToolResult ClaireonWidgetBPTool_Create::Execute(const TSharedPtr<FJsonObject>& 
 		}
 		else if (NewWBP->WidgetTree)
 		{
-			UWidget* Root = NewWBP->WidgetTree->ConstructWidget<UWidget>(RootClass, FName(*RootClass->GetName()));
+			UWidget* Root = ClaireonWidgetHelpers::CreateWidget(NewWBP->WidgetTree, RootClass, FName(*RootClass->GetName()));
 			if (Root)
 			{
 				NewWBP->WidgetTree->RootWidget = Root;

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_Create.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_Create.cpp
@@ -3,6 +3,7 @@
 
 #include "Tools/ClaireonWidgetBPTool_Create.h"
 #include "Tools/FToolSchemaBuilder.h"
+#include "Tools/ClaireonAssetUtils.h"
 #include "Dom/JsonObject.h"
 #include "ClaireonLog.h"
 #include "ClaireonNameResolver.h"
@@ -123,6 +124,10 @@ FToolResult ClaireonWidgetBPTool_Create::Execute(const TSharedPtr<FJsonObject>& 
 	{
 		return MakeErrorResult(FString::Printf(TEXT("Failed to create package: %s"), *PackageName));
 	}
+
+	// Deleting the .uasset on disk above does not evict a same-named object still loaded in
+	// memory; UE 5.8 CreateBlueprint asserts the name is free, so clear it first.
+	ClaireonAssetUtils::EvictInMemoryObject(Package, AssetName);
 
 	// Create widget blueprint
 	UWidgetBlueprint* NewWBP = CastChecked<UWidgetBlueprint>(

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_RemoveWidget.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_RemoveWidget.cpp
@@ -62,6 +62,8 @@ FToolResult ClaireonWidgetBPTool_RemoveWidget::Execute(const TSharedPtr<FJsonObj
 	Tree->SetFlags(RF_Transactional);
 	Tree->Modify();
 
+	const FName RemovedWidgetName = Widget->GetFName();
+
 	if (Tree->RootWidget == Widget)
 	{
 		Tree->RootWidget = nullptr;
@@ -71,11 +73,13 @@ FToolResult ClaireonWidgetBPTool_RemoveWidget::Execute(const TSharedPtr<FJsonObj
 		Tree->RemoveWidget(Widget);
 	}
 
+	ClaireonWidgetHelpers::TrashRemovedWidget(WBP, Widget);
+
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
 	Data->bModified = true;
 
 	// Clear focus if the focused widget was removed
-	if (Data->FocusedWidget == Widget->GetFName())
+	if (Data->FocusedWidget == RemovedWidgetName)
 	{
 		Data->FocusedWidget = Tree->RootWidget ? Tree->RootWidget->GetFName() : NAME_None;
 	}

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_RenameWidget.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_RenameWidget.cpp
@@ -78,6 +78,11 @@ FToolResult ClaireonWidgetBPTool_RenameWidget::Execute(const TSharedPtr<FJsonObj
 
 	FName OldFName = Widget->GetFName();
 
+	// Update the GUID bookkeeping before the object rename: Rename() broadcasts
+	// and can trigger an immediate recompile, whose validation expects the map to
+	// already know the new name.
+	ClaireonWidgetHelpers::NotifyVariableRenamed(WBP, OldFName, FName(*NewName));
+
 	// Rename the UObject
 	Widget->Rename(*NewName, Widget->GetOuter());
 

--- a/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_ReplaceWidget.cpp
+++ b/Source/Claireon/Private/Tools/ClaireonWidgetBPTool_ReplaceWidget.cpp
@@ -137,11 +137,14 @@ FToolResult ClaireonWidgetBPTool_ReplaceWidget::Execute(const TSharedPtr<FJsonOb
 		UE_LOG(LogClaireon, Warning, TEXT("[EditWidgetBP] Replacement widget '%s' is not a panel -- %d children were lost"), *NewWidgetClassStr, OldChildren.Num());
 	}
 
+	const FName OldWidgetFName = OldWidget->GetFName();
+	ClaireonWidgetHelpers::TrashRemovedWidget(WBP, OldWidget);
+
 	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
 	Data->bModified = true;
 
 	// Update focus if needed
-	if (Data->FocusedWidget == OldWidget->GetFName())
+	if (Data->FocusedWidget == OldWidgetFName)
 	{
 		Data->FocusedWidget = NewWidget->GetFName();
 	}

--- a/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_BehaviorTree.cpp
+++ b/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_BehaviorTree.cpp
@@ -390,7 +390,7 @@ bool FClaireonDeltaApplicator_BehaviorTree::ApplyPhase3_Create(const FString& Se
 					if (Prop.Value->TryGetString(PropValue))
 					{
 						FString PropError;
-						if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(InstNode, Prop.Key, PropValue, PropError))
+						if (!ClaireonBehaviorTreeHelpers::SetBTNodeProperty(InstNode, FString(*Prop.Key), PropValue, PropError))
 						{
 							AddWarning(FString::Printf(TEXT("behaviortree_apply_delta: nodes[%d].properties.%s: %s"),
 								i, *Prop.Key, *PropError));

--- a/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_Material.cpp
+++ b/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_Material.cpp
@@ -260,7 +260,7 @@ bool FClaireonDeltaApplicator_Material::ApplyPhase3_Create(const FString& Sessio
 				if (!Pair.Value.IsValid()) { continue; }
 				const FString TextValue = Pair.Value->AsString();
 				FString PropErr;
-				if (!ClaireonMaterialHelpers::SetExpressionProperty(Mat, Expr, Pair.Key, TextValue, PropErr))
+				if (!ClaireonMaterialHelpers::SetExpressionProperty(Mat, Expr, FString(*Pair.Key), TextValue, PropErr))
 				{
 					AddWarning(FString::Printf(TEXT("material_apply_delta: nodes[%d] property '%s': %s"),
 						i, *Pair.Key, *PropErr));

--- a/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_PCGGraph.cpp
+++ b/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_PCGGraph.cpp
@@ -290,7 +290,7 @@ bool FClaireonDeltaApplicator_PCGGraph::ApplyPhase3_Create(const FString& Sessio
 				if (Prop.Value->TryGetString(PropValue))
 				{
 					FString PropError;
-					if (!ClaireonPCGGraphHelpers::SetNodeProperty(NewNode, Prop.Key, PropValue, PropError))
+					if (!ClaireonPCGGraphHelpers::SetNodeProperty(NewNode, FString(*Prop.Key), PropValue, PropError))
 					{
 						AddWarning(FString::Printf(TEXT("pcg_apply_delta: nodes[%d].properties.%s: %s"), i, *Prop.Key, *PropError));
 					}

--- a/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_WidgetBP.cpp
+++ b/Source/Claireon/Private/Tools/FClaireonDeltaApplicator_WidgetBP.cpp
@@ -169,6 +169,7 @@ bool FClaireonDeltaApplicator_WidgetBP::ApplyPhase2_Remove(const FString& Sessio
 		{
 			Tree->RemoveWidget(Widget);
 		}
+		ClaireonWidgetHelpers::TrashRemovedWidget(WBP, Widget);
 		FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
 		MarkRemoved();
 		RecordAffected(Ref);
@@ -373,6 +374,7 @@ void FClaireonDeltaApplicator_WidgetBP::Phase3CleanupOnFailure(const FString& Se
 		{
 			if (Tree->RootWidget == W) { Tree->RootWidget = nullptr; }
 			else { Tree->RemoveWidget(W); }
+			ClaireonWidgetHelpers::TrashRemovedWidget(WBP, W);
 		}
 	}
 	CreatedWidgetsThisCall.Reset();

--- a/Source/Claireon/Public/ClaireonWidgetHelpers.h
+++ b/Source/Claireon/Public/ClaireonWidgetHelpers.h
@@ -48,6 +48,27 @@ namespace ClaireonWidgetHelpers
 	/** Create a widget in a widget tree with RF_Transactional. */
 	UWidget* CreateWidget(UWidgetTree* Tree, TSubclassOf<UWidget> WidgetClass, FName WidgetName = NAME_None);
 
+	/**
+	 * Keep UWidgetBlueprint::WidgetVariableNameToGuidMap in sync with widget and
+	 * animation variable lifecycle. UE 5.8's widget compiler ensures every widget
+	 * and animation has a GUID entry; earlier engines have no such map, so these
+	 * are no-ops there. CreateWidget already notifies for the tree's owning
+	 * blueprint; call these directly for renames, removals, and objects created
+	 * outside CreateWidget (e.g. animations).
+	 */
+	void NotifyVariableAdded(UWidgetBlueprint* WidgetBP, FName VariableName);
+	void NotifyVariableRemoved(UWidgetBlueprint* WidgetBP, FName VariableName);
+	void NotifyVariableRenamed(UWidgetBlueprint* WidgetBP, FName OldName, FName NewName);
+
+	/**
+	 * Reparent a removed widget and its remaining children to the transient package
+	 * (the designer's delete pattern, see FWidgetBlueprintEditorUtils::DeleteWidgets)
+	 * so their names don't collide with future widgets and they stop counting as
+	 * source widgets, then drop their variable GUID entries. Call after the widget
+	 * has been detached from the tree.
+	 */
+	void TrashRemovedWidget(UWidgetBlueprint* WidgetBP, UWidget* Widget);
+
 	/** Add a child widget to a panel widget and configure slot properties. */
 	UPanelSlot* AddChildToPanel(UPanelWidget* Parent, UWidget* Child, const TSharedPtr<FJsonObject>& SlotProperties = nullptr);
 

--- a/Source/Claireon/Public/Tools/ClaireonAssetUtils.h
+++ b/Source/Claireon/Public/Tools/ClaireonAssetUtils.h
@@ -113,4 +113,17 @@ namespace ClaireonAssetUtils
 	// Resolve a UClass by name, accepting either the "U"/"A"-prefixed or unprefixed
 	// form (UClass::GetName() omits the prefix). Returns nullptr if no match.
 	CLAIREON_API UClass* ResolveClassName(const FString& ClassName);
+
+	/**
+	 * Evict any in-memory UObject occupying AssetName within Package, moving it into the
+	 * transient package (renamed, cleared of public/standalone flags, marked garbage).
+	 *
+	 * The "recreate asset in place" idiom deletes the .uasset on disk before calling a
+	 * create/duplicate API, but that does NOT remove an object already loaded in memory
+	 * (e.g. from an earlier create this editor session). On UE 5.8
+	 * FKismetEditorUtilities::CreateBlueprint and StaticDuplicateObject assert
+	 * FindObject(Outer, Name) == nullptr, so callers must clear the slot first.
+	 * No-op if Package is null or the name is free.
+	 */
+	CLAIREON_API void EvictInMemoryObject(UPackage* Package, const FString& AssetName);
 }

--- a/Source/Claireon/Public/Tools/ClaireonTool_GasActivateAbility.h
+++ b/Source/Claireon/Public/Tools/ClaireonTool_GasActivateAbility.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Tools/IClaireonTool.h"
+
+/**
+ * gas_activate_ability -- actually activate an already-granted ability on a live
+ * actor's ASC (unlike pie_test_ability, which only dry-run checks
+ * CanActivateAbility). Address it by spec_handle_id or ability_name. Engine GAS
+ * API only.
+ */
+class ClaireonTool_GasActivateAbility : public IClaireonTool
+{
+public:
+	virtual FString GetCategory() const override;
+	virtual FString GetOperation() const override;
+	virtual FString GetDescription() const override;
+	virtual TSharedPtr<FJsonObject> GetInputSchema() const override;
+	virtual EClaireonToolSessionMode GetSessionMode() const override;
+	virtual FToolResult Execute(const TSharedPtr<FJsonObject>& Arguments) override;
+};

--- a/Source/Claireon/Public/Tools/ClaireonTool_GasApplyEffect.h
+++ b/Source/Claireon/Public/Tools/ClaireonTool_GasApplyEffect.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Tools/IClaireonTool.h"
+
+/**
+ * gas_apply_effect -- apply a GameplayEffect to a live actor's ASC (the
+ * promoted "jank" aspect test: point it at an aspect's GE_*_C and watch the
+ * mechanic take effect). Supports level, SetByCaller magnitudes, and a
+ * duration override. Defaults to the server world. Engine GAS API only.
+ */
+class ClaireonTool_GasApplyEffect : public IClaireonTool
+{
+public:
+	virtual FString GetCategory() const override;
+	virtual FString GetOperation() const override;
+	virtual FString GetDescription() const override;
+	virtual TSharedPtr<FJsonObject> GetInputSchema() const override;
+	virtual EClaireonToolSessionMode GetSessionMode() const override;
+	virtual FToolResult Execute(const TSharedPtr<FJsonObject>& Arguments) override;
+};

--- a/Source/Claireon/Public/Tools/ClaireonTool_GasGrantAbility.h
+++ b/Source/Claireon/Public/Tools/ClaireonTool_GasGrantAbility.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Tools/IClaireonTool.h"
+
+/**
+ * gas_grant_ability -- grant a GameplayAbility to a live actor's ASC (server
+ * authority) and optionally activate it. How a designer tests a freshly
+ * authored GA_. Engine GAS API only.
+ */
+class ClaireonTool_GasGrantAbility : public IClaireonTool
+{
+public:
+	virtual FString GetCategory() const override;
+	virtual FString GetOperation() const override;
+	virtual FString GetDescription() const override;
+	virtual TSharedPtr<FJsonObject> GetInputSchema() const override;
+	virtual EClaireonToolSessionMode GetSessionMode() const override;
+	virtual FToolResult Execute(const TSharedPtr<FJsonObject>& Arguments) override;
+};

--- a/Source/Claireon/Public/Tools/ClaireonTool_GasInspect.h
+++ b/Source/Claireon/Public/Tools/ClaireonTool_GasInspect.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Tools/IClaireonTool.h"
+
+/**
+ * gas_runtime_inspect -- full read-only snapshot of a live actor's AbilitySystemComponent
+ * (granted abilities, active gameplay effects, attributes, owned tags). The
+ * diagnostic backbone for verifying authored aspects/GEs and debugging equip
+ * flow. Engine GAS API only.
+ */
+class ClaireonTool_GasInspect : public IClaireonTool
+{
+public:
+	virtual FString GetCategory() const override;
+	virtual FString GetOperation() const override;
+	virtual FString GetDescription() const override;
+	virtual TSharedPtr<FJsonObject> GetInputSchema() const override;
+	virtual EClaireonToolSessionMode GetSessionMode() const override;
+	virtual FToolResult Execute(const TSharedPtr<FJsonObject>& Arguments) override;
+};

--- a/Source/Claireon/Public/Tools/ClaireonTool_GasRemoveEffect.h
+++ b/Source/Claireon/Public/Tools/ClaireonTool_GasRemoveEffect.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Tools/IClaireonTool.h"
+
+/**
+ * gas_remove_effect -- remove an applied GameplayEffect from a live actor's ASC,
+ * addressed either by effect_handle_id (from gas_runtime_inspect / gas_apply_effect) or
+ * by effect class (removes all matching). Defaults to the server world. Engine
+ * GAS API only.
+ */
+class ClaireonTool_GasRemoveEffect : public IClaireonTool
+{
+public:
+	virtual FString GetCategory() const override;
+	virtual FString GetOperation() const override;
+	virtual FString GetDescription() const override;
+	virtual TSharedPtr<FJsonObject> GetInputSchema() const override;
+	virtual EClaireonToolSessionMode GetSessionMode() const override;
+	virtual FToolResult Execute(const TSharedPtr<FJsonObject>& Arguments) override;
+};

--- a/Source/Claireon/Public/Tools/ClaireonTool_GasSetAttribute.h
+++ b/Source/Claireon/Public/Tools/ClaireonTool_GasSetAttribute.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Tools/IClaireonTool.h"
+
+/**
+ * gas_set_attribute -- set an attribute's base or current value on a live
+ * actor's ASC (e.g. drop Health to test a threshold aspect). Engine GAS API only.
+ */
+class ClaireonTool_GasSetAttribute : public IClaireonTool
+{
+public:
+	virtual FString GetCategory() const override;
+	virtual FString GetOperation() const override;
+	virtual FString GetDescription() const override;
+	virtual TSharedPtr<FJsonObject> GetInputSchema() const override;
+	virtual EClaireonToolSessionMode GetSessionMode() const override;
+	virtual FToolResult Execute(const TSharedPtr<FJsonObject>& Arguments) override;
+};

--- a/Source/Claireon/Public/Tools/ClaireonTool_GasSetTags.h
+++ b/Source/Claireon/Public/Tools/ClaireonTool_GasSetTags.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 The Claireon Contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Tools/IClaireonTool.h"
+
+/**
+ * gas_set_tags -- add or remove loose gameplay tags on a live actor's ASC, to
+ * simulate a trigger/state condition (e.g. add a state tag so an aspect's
+ * HitModifier condition fires). Engine GAS API only.
+ */
+class ClaireonTool_GasSetTags : public IClaireonTool
+{
+public:
+	virtual FString GetCategory() const override;
+	virtual FString GetOperation() const override;
+	virtual FString GetDescription() const override;
+	virtual TSharedPtr<FJsonObject> GetInputSchema() const override;
+	virtual EClaireonToolSessionMode GetSessionMode() const override;
+	virtual FToolResult Execute(const TSharedPtr<FJsonObject>& Arguments) override;
+};


### PR DESCRIPTION
## Summary

Reconciliation of #8 and #9, as promised on both threads. This branch merges the two ports into one version-gated series that compiles and links against stock **UE 5.5, 5.6, 5.7, and 5.8** (verified via a standalone host project on each), plus a full editor build and live in-editor testing on our production 5.5 fork.

**Commit 1 — #9 essentially as-is** (authored to @nkmlombardi): the `UE_VERSION_OLDER_THAN(5, 8, 0)` gating approach, `FString(*Pair.Key)` for the `FSharedString` JSON keys, StateTree binding API via the `FClaireonPropertyPath` alias, camera `FCameraBuildContext`, chooser `TArrayView<int>`, and the full widget/animation `WidgetVariableNameToGuidMap` lifecycle (both documented subtleties — the transient-package reparent and rename-bookkeeping-before-`UObject::Rename` — held up in live testing).

**Commit 2 — the #8 runtime-fix harvest** (authored to @Maulth): `EvictInMemoryObject` (generalized into a `ClaireonAssetUtils` helper and applied at every create/duplicate site), PythonScriptPlugin dynamic-load (gated to 5.8+ so earlier engines keep the static link), `created_node_guid` on add_node, the MVVM `(class, name)` constructor, `add_rig` on-demand director install, trace null-guards + unknown-session error, and the DeveloperSettings disambiguation. Also adopts #8's camera-spec direction: those `BV*CameraNode` names were our internal fork's camera nodes leaking into the OSS tests (sorry!) — scrubbed, using `FieldOfViewCameraNode`/`PostProcessCameraNode`/`BoomArmCameraNode` so the specs resolve on 5.5-5.7 as well as 5.8 (`SplineOrbitCameraNode` is 5.8-only), with #8's numeric float compares.

**Commit 3 — bp_compile flag split**: `SkipSave` on every engine (the save-on-compile disk-write contract bug exists on all versions; matches `UBlueprintEditorLibrary::CompileBlueprint`), `SkipGarbageCollection` on 5.8 only, where the livelock reproduces — earlier engines keep the engine-default GC (live-verified on 5.5: 86 ms compile with GC on, from inside the MCP request handler).

**Not taken** (with reasons):
- #8's ungated 5.8 rewrites — superseded by #9's gated equivalents, per the note in #8's own description.
- #8's `SaveAsset` `TryConvertLongPackageNameToFilename` fix — we fix the same bug with a `DoesPackageExist` -> `TryConvert` fallback (also handles existing-but-moved packages); that variant is in this branch.
- #8's node-title `NormalizedForMatch` and `ParseVariableType` String fallback — behavior changes to node matching we'd like to evaluate separately.
- #8's 133/149 test-expectation updates that were 5.8-only renames.

## Verification
- Compiles + links against stock UE 5.5 / 5.6 / 5.7 / 5.8 (standalone host project per engine)
- Live editor testing on a production 5.5 project: bp_compile (86 ms, no disk write), widget GUID lifecycle, camera automation specs (identical pass/fail set vs pre-change baseline; the 3 failures are pre-existing save-path issues on 5.5 headless, unrelated to these changes)

Closes #8. Closes #9.

Thanks @Maulth and @nkmlombardi — complementary ports, and both are credited as commit authors here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
